### PR TITLE
A-1: Document owner-only security settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,28 @@ Sicherheitsupdates werden in zwei Stufen geprüft:
 - GitHub Actions führt `pip-audit` gegen die Laufzeit-Lockdatei aus. Bekannte
   Abhängigkeitsschwachstellen lassen den Workflow fehlschlagen.
 
+### Einmalige GitHub-Einstellungen für den Repository-Owner
+
+Einige Schutzfunktionen liegen nicht im Repository und können deshalb nicht durch
+einen Commit aktiviert werden. Der Owner sollte einmalig in den
+Repository-Einstellungen prüfen:
+
+- **Dependabot Alerts** und **Dependabot Security Updates** aktivieren. Die Datei
+  `.github/dependabot.yml` übernimmt danach die wöchentlichen, in CI geprüften
+  Versionsupdates.
+- `main` mit einer Branch-Regel oder einem Ruleset schützen, den Workflow **CI**
+  als erforderlichen Check setzen und Force-Push sowie Branch-Löschung
+  deaktivieren.
+- **Secret Scanning** aktivieren, falls es für den verwendeten GitHub-Tarif
+  verfügbar ist.
+- Optional **Code Scanning/CodeQL** aktivieren, falls es für das private
+  Repository verfügbar ist. Ruff Security und `pip-audit` laufen unabhängig
+  davon bereits bei jedem Push und Pull Request.
+
+Nur ein Repository-Owner oder Benutzer mit Admin-Rechten kann diese Einstellungen
+ändern. Der aktuelle Zustand lässt sich unter **Settings → Security** und
+**Settings → Rules** kontrollieren.
+
 Voraussetzung ist **Python 3.10 oder neuer**. Empfohlen wird Raspberry Pi OS
 Bookworm 64 Bit mit Python 3.11. Python 3.9 wird nicht mehr unterstützt, weil die
 bereinigte Pillow-Version 12.3.0 mindestens Python 3.10 benötigt.


### PR DESCRIPTION
## Context

Completes the README documentation for the final A-1 security hardening. Repository-level controls cannot be configured through source code and require owner/admin permissions.

## What changed

- Adds a one-time owner checklist for Dependabot Alerts and Security Updates.
- Documents the recommended main branch protection and required CI check.
- Documents optional Secret Scanning and CodeQL availability.
- Clarifies that Ruff Security and pip-audit already run independently in CI.

## Product impact

Documentation only; runtime behavior is unchanged.

## Verification

- 81 tests passed.
- Ruff passed.
- Markdown diff check passed.

## Limitation

The currently authenticated GitHub account has write access but GitHub reports that it does not have access to repository options. An owner/admin must apply the documented settings.

This change has been created with the support of Codex. Please review carefully to confirm that the acceptance criteria are met.