### PR TITLE
A-1: Secure Geofox credential setup during installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,10 +84,10 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Check Bash syntax
-        run: bash -n install.sh diagnose.sh
+        run: bash -n install.sh configure-credentials.sh diagnose.sh
 
       - name: Run ShellCheck
-        run: shellcheck install.sh diagnose.sh
+        run: shellcheck install.sh configure-credentials.sh diagnose.sh
 
       - name: Verify log cleanup systemd units
         run: |

--- a/README.md
+++ b/README.md
@@ -263,7 +263,10 @@ Das Skript:
 - installiert die benötigten System- und Python-Pakete,
 - aktiviert SPI,
 - installiert die Anwendung unter `/opt/hvv-anzeiger`,
-- übernimmt eine vorhandene `config.json` und Zugangsdaten unverändert,
+- fragt bei der ersten Installation die Geofox Application-ID und das Passwort
+  interaktiv ab; das Passwort bleibt bei der Eingabe unsichtbar,
+- übernimmt eine vorhandene `config.json` und vollständige Zugangsdaten bei
+  späteren Updates unverändert,
 - stoppt bei einer Wiederholungsinstallation zuerst den laufenden Dienst,
 - sichert die bisherige Python-Umgebung und stellt sie bei einem Installationsfehler
   automatisch wieder her,
@@ -276,10 +279,11 @@ Das Skript:
 - aktiviert die wöchentliche Journal-Bereinigung,
 - aktiviert den Autostart.
 
-Die Zugangsdaten werden nicht als Kommandozeilenparameter abgefragt oder
-gespeichert. Wenn sie noch fehlen, nennt das Skript am Ende die beiden
-erforderlichen Befehle. Nach der erstmaligen SPI-Aktivierung sollte der
-Raspberry Pi neu gestartet werden.
+Die Zugangsdaten werden weder als Kommandozeilenparameter noch im Repository
+gespeichert. Der Installer schreibt sie atomar mit den Dateirechten `0600` nach
+`/etc/hvv-anzeiger.env`. Bricht die Eingabe ab oder bleibt ein Wert leer, startet
+der Dienst nicht mit einer unvollständigen Konfiguration. Nach der erstmaligen
+SPI-Aktivierung sollte der Raspberry Pi neu gestartet werden.
 
 ### Manuelle Installation
 
@@ -331,7 +335,8 @@ sudo install -d -m 0755 -o root -g root /opt/hvv-anzeiger
 sudo cp -R hvv_display systemd /opt/hvv-anzeiger/
 sudo install -m 0644 README.md config.example.json pyproject.toml \
   requirements.txt /opt/hvv-anzeiger/
-sudo install -m 0755 diagnose.sh /opt/hvv-anzeiger/diagnose.sh
+sudo install -m 0755 configure-credentials.sh diagnose.sh \
+  /opt/hvv-anzeiger/
 sudo install -d -m 0750 -o hvv-anzeiger -g hvv-anzeiger \
   /opt/hvv-anzeiger/var
 
@@ -350,22 +355,25 @@ steht, `display.rotate` von `0` auf `2` ändern. Bei vertauschten Farben
 
 ### 3. Geofox-Zugangsdaten hinterlegen
 
-Die von Geofox erhaltene Application-ID und das Passwort werden in einer
-geschützten Systemdatei gespeichert:
+Die von Geofox erhaltene Application-ID und das Passwort werden einmalig
+interaktiv abgefragt und in einer geschützten Systemdatei gespeichert. Das
+Passwort ist während der Eingabe nicht sichtbar:
 
 ```bash
-sudo install -m 600 /dev/null /etc/hvv-anzeiger.env
-sudo nano /etc/hvv-anzeiger.env
+./configure-credentials.sh
 ```
 
-Folgenden Inhalt eintragen:
+Eine Wiederholungsinstallation übernimmt vollständige Zugangsdaten automatisch.
+Um sie später bewusst zu ersetzen:
 
-```text
-GEOFOX_USER=DEINE_APPLICATION_ID
-GEOFOX_PASSWORD=DEIN_PASSWORT
+```bash
+cd /opt/hvv-anzeiger
+./configure-credentials.sh --force
+sudo systemctl restart hvv-anzeiger
 ```
 
-Keine Anführungszeichen um die Werte schreiben.
+Das Hilfsskript gibt das Passwort nie aus, speichert Sonderzeichen korrekt und
+setzt Eigentümer und Rechte der Datei auf `root:root` und `0600`.
 
 ### 4. Einmaliger Funktionstest
 
@@ -516,8 +524,8 @@ python3.11 -m venv .venv
 .venv/bin/coverage report
 .venv/bin/pip-audit --requirement requirements.txt --disable-pip
 .venv/bin/hvv-preview preview.png
-bash -n install.sh diagnose.sh
-shellcheck install.sh diagnose.sh
+bash -n install.sh configure-credentials.sh diagnose.sh
+shellcheck install.sh configure-credentials.sh diagnose.sh
 ```
 
 Die automatisierten Tests prüfen unter anderem:
@@ -540,6 +548,8 @@ Die automatisierten Tests prüfen unter anderem:
 - verbundene, getrennte, unbekannte und alternativ benannte WLAN-Schnittstellen,
 - normale, leere und veraltete Anzeigezustände,
 - Screenshot, Installationsskript, Pi-Diagnose und systemd-Konfiguration.
+- einmalige, verdeckte Zugangsdatenabfrage, sichere Dateirechte, Wiederverwendung
+  vorhandener Zugangsdaten und bewusste Rotation mit `--force`.
 
 GitHub Actions führt diese Prüfungen nach jedem Push und für jeden Pull Request mit
 Python 3.10, 3.11 und 3.13 aus. Zusätzlich werden Ruff einschließlich seiner

--- a/configure-credentials.sh
+++ b/configure-credentials.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+ENV_FILE="${HVV_ENV_FILE:-/etc/hvv-anzeiger.env}"
+FORCE=0
+ROOT_TEMP_FILE=""
+geofox_user=""
+geofox_password=""
+
+cleanup() {
+  if [[ -n "$ROOT_TEMP_FILE" ]]; then
+    sudo rm -f -- "$ROOT_TEMP_FILE" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+fail() {
+  echo "Fehler: $*" >&2
+  exit 1
+}
+
+usage() {
+  cat <<'EOF'
+Verwendung: ./configure-credentials.sh [--force]
+
+Speichert die Geofox Application-ID und das Passwort geschützt unter
+/etc/hvv-anzeiger.env. Vorhandene vollständige Zugangsdaten bleiben ohne
+--force unverändert.
+EOF
+}
+
+credential_present() {
+  local key="$1"
+  [[ -e "$ENV_FILE" ]] || return 1
+  sudo awk -v key="$key" '
+    index($0, key "=") == 1 {
+      value = substr($0, length(key) + 2)
+      if (value != "" && value != "\"\"" && value != "\047\047") {
+        found = 1
+      }
+    }
+    END { exit found ? 0 : 1 }
+  ' "$ENV_FILE"
+}
+
+credentials_complete() {
+  credential_present "GEOFOX_USER" &&
+    credential_present "GEOFOX_PASSWORD"
+}
+
+prompt_nonempty() {
+  local variable_name="$1"
+  local prompt="$2"
+  local hidden="$3"
+  local value=""
+
+  while [[ ! "$value" =~ [^[:space:]] ]]; do
+    if [[ "$hidden" == "true" ]]; then
+      IFS= read -r -s -p "$prompt" value ||
+        fail "Eingabe wurde abgebrochen."
+      echo
+    else
+      IFS= read -r -p "$prompt" value ||
+        fail "Eingabe wurde abgebrochen."
+    fi
+    if [[ ! "$value" =~ [^[:space:]] ]]; then
+      echo "Der Wert darf nicht leer sein." >&2
+    fi
+  done
+
+  if [[ "$value" == *$'\r'* || "$value" == *$'\n'* ]]; then
+    fail "Zugangsdaten dürfen keinen Zeilenumbruch enthalten."
+  fi
+  printf -v "$variable_name" "%s" "$value"
+}
+
+quote_environment_value() {
+  local escaped="$1"
+  escaped="${escaped//\\/\\\\}"
+  escaped="${escaped//\"/\\\"}"
+  escaped="${escaped//\$/\\$}"
+  escaped="${escaped//\`/\\\`}"
+  printf '"%s"' "$escaped"
+}
+
+write_credentials() {
+  local user="$1"
+  local password="$2"
+
+  ROOT_TEMP_FILE="$(sudo mktemp "${ENV_FILE}.tmp.XXXXXX")"
+  {
+    printf "GEOFOX_USER="
+    quote_environment_value "$user"
+    printf "\nGEOFOX_PASSWORD="
+    quote_environment_value "$password"
+    printf "\n"
+  } | sudo tee "$ROOT_TEMP_FILE" >/dev/null
+  sudo chown root:root "$ROOT_TEMP_FILE"
+  sudo chmod 0600 "$ROOT_TEMP_FILE"
+  sudo mv -f -- "$ROOT_TEMP_FILE" "$ENV_FILE"
+  ROOT_TEMP_FILE=""
+}
+
+case "${1:-}" in
+  "")
+    ;;
+  --force)
+    FORCE=1
+    ;;
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  *)
+    usage >&2
+    fail "Unbekannte Option: $1"
+    ;;
+esac
+
+command -v sudo >/dev/null 2>&1 || fail "sudo wurde nicht gefunden."
+if [[ "${EUID}" -eq 0 ]]; then
+  fail "Bitte als normaler Benutzer starten (nicht mit sudo)."
+fi
+
+if ((FORCE == 0)) && credentials_complete; then
+  sudo chown root:root "$ENV_FILE"
+  sudo chmod 0600 "$ENV_FILE"
+  echo "Geofox-Zugangsdaten sind bereits vollständig hinterlegt."
+  exit 0
+fi
+
+echo "Geofox-Zugangsdaten einrichten"
+echo "Das Passwort bleibt bei der Eingabe unsichtbar."
+prompt_nonempty geofox_user "Geofox Application-ID: " false
+prompt_nonempty geofox_password "Geofox Passwort: " true
+write_credentials "$geofox_user" "$geofox_password"
+unset geofox_password
+
+echo "Geofox-Zugangsdaten wurden geschützt in ${ENV_FILE} gespeichert."

--- a/diagnose.sh
+++ b/diagnose.sh
@@ -26,6 +26,20 @@ fail() {
   FAILURES=$((FAILURES + 1))
 }
 
+credential_present() {
+  local key="$1"
+  [[ -e "$ENV_FILE" ]] || return 1
+  sudo awk -v key="$key" '
+    index($0, key "=") == 1 {
+      value = substr($0, length(key) + 2)
+      if (value != "" && value != "\"\"" && value != "\047\047") {
+        found = 1
+      }
+    }
+    END { exit found ? 0 : 1 }
+  ' "$ENV_FILE"
+}
+
 if [[ "$(uname -s)" == "Linux" ]]; then
   pass "Linux erkannt ($(uname -m))"
 else
@@ -75,8 +89,8 @@ else
   fail "Die installierte Anwendung wurde unter $APP_DIR nicht gefunden."
 fi
 
-if sudo grep -Eq '^GEOFOX_USER=.+$' "$ENV_FILE" 2>/dev/null &&
-  sudo grep -Eq '^GEOFOX_PASSWORD=.+$' "$ENV_FILE" 2>/dev/null; then
+if credential_present "GEOFOX_USER" &&
+  credential_present "GEOFOX_PASSWORD"; then
   pass "Geofox-Zugangsdaten sind hinterlegt."
 else
   fail "Geofox-Zugangsdaten fehlen oder sind unvollständig."

--- a/install.sh
+++ b/install.sh
@@ -112,6 +112,7 @@ if [[ "$(realpath "$SOURCE_DIR")" != "$(realpath "$APP_DIR")" ]]; then
     "$SOURCE_DIR/requirements.txt" \
     "$APP_DIR/"
   sudo install -m 0755 \
+    "$SOURCE_DIR/configure-credentials.sh" \
     "$SOURCE_DIR/diagnose.sh" \
     "$SOURCE_DIR/install.sh" \
     "$APP_DIR/"
@@ -144,10 +145,8 @@ fi
 sudo chown root:root "$APP_DIR/config.json"
 sudo chmod 0644 "$APP_DIR/config.json"
 
-echo "[7/8] Zugangsdaten-Datei vorbereiten"
-if [[ ! -e "$ENV_FILE" ]]; then
-  sudo install -m 0600 -o root -g root /dev/null "$ENV_FILE"
-fi
+echo "[7/8] Geofox-Zugangsdaten einrichten"
+HVV_ENV_FILE="$ENV_FILE" "$SOURCE_DIR/configure-credentials.sh"
 
 echo "[8/8] Autostart installieren"
 sudo install -m 0644 \
@@ -158,22 +157,10 @@ sudo systemctl daemon-reload
 sudo systemctl enable "$SERVICE_NAME"
 sudo systemctl enable --now "$LOG_CLEANUP_TIMER"
 
-if sudo grep -Eq '^GEOFOX_USER=.+$' "$ENV_FILE" &&
-  sudo grep -Eq '^GEOFOX_PASSWORD=.+$' "$ENV_FILE"; then
-  sudo systemctl restart "$SERVICE_NAME"
-  echo
-  echo "Installation abgeschlossen. Der Dienst läuft."
-  echo "Status: systemctl status ${SERVICE_NAME}"
-else
-  echo
-  echo "Installation abgeschlossen. Vor dem Start fehlen noch die Geofox-Zugangsdaten:"
-  echo "  sudo nano ${ENV_FILE}"
-  echo "  GEOFOX_USER=DEINE_APPLICATION_ID"
-  echo "  GEOFOX_PASSWORD=DEIN_PASSWORT"
-  echo
-  echo "Danach starten:"
-  echo "  sudo systemctl start ${SERVICE_NAME}"
-fi
+sudo systemctl restart "$SERVICE_NAME"
+echo
+echo "Installation abgeschlossen. Der Dienst wurde gestartet."
+echo "Status: systemctl status ${SERVICE_NAME}"
 
 if ((VENV_BACKED_UP == 1)); then
   sudo rm -rf "$VENV_BACKUP"

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -1,0 +1,146 @@
+import os
+import stat
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIGURE = ROOT / "configure-credentials.sh"
+
+
+class CredentialConfigurationTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.directory = Path(self.temporary_directory.name)
+        self.env_file = self.directory / "hvv-anzeiger.env"
+        fake_bin = self.directory / "bin"
+        fake_bin.mkdir()
+        sudo = fake_bin / "sudo"
+        sudo.write_text(
+            """#!/bin/sh
+if [ "$1" = "chown" ]; then
+  exit 0
+fi
+if [ "$1" = "install" ]; then
+  shift
+  set -- "$1" "$2" "$7" "$8"
+  exec install "$@"
+fi
+exec "$@"
+""",
+            encoding="utf-8",
+        )
+        sudo.chmod(0o755)
+        self.environment = {
+            **os.environ,
+            "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+            "HVV_ENV_FILE": str(self.env_file),
+        }
+
+    def tearDown(self) -> None:
+        self.temporary_directory.cleanup()
+
+    def run_configure(
+        self, user_input: str, *arguments: str
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(  # noqa: S603
+            [str(CONFIGURE), *arguments],
+            input=user_input,
+            text=True,
+            capture_output=True,
+            env=self.environment,
+            check=False,
+        )
+
+    def test_first_run_prompts_and_stores_credentials_securely(self) -> None:
+        result = self.run_configure('application-id\npa"ss\\word$42\n')
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            self.env_file.read_text(encoding="utf-8"),
+            'GEOFOX_USER="application-id"\n'
+            'GEOFOX_PASSWORD="pa\\"ss\\\\word\\$42"\n',
+        )
+        self.assertEqual(stat.S_IMODE(self.env_file.stat().st_mode), 0o600)
+        self.assertNotIn('pa"ss\\word$42', result.stdout + result.stderr)
+        self.assertIn("gespeichert", result.stdout)
+        loaded = subprocess.run(  # noqa: S603
+            [
+                "/bin/bash",
+                "-c",
+                '. "$1"; printf "%s\\n%s\\n" "$GEOFOX_USER" "$GEOFOX_PASSWORD"',
+                "bash",
+                str(self.env_file),
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(loaded.returncode, 0, loaded.stderr)
+        self.assertEqual(loaded.stdout, 'application-id\npa"ss\\word$42\n')
+
+    def test_existing_complete_credentials_are_kept_without_prompt(self) -> None:
+        original = 'GEOFOX_USER="old-user"\nGEOFOX_PASSWORD="old-password"\n'
+        self.env_file.write_text(original, encoding="utf-8")
+        self.env_file.chmod(0o644)
+
+        result = self.run_configure("")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self.env_file.read_text(encoding="utf-8"), original)
+        self.assertEqual(stat.S_IMODE(self.env_file.stat().st_mode), 0o600)
+        self.assertIn("bereits vollständig", result.stdout)
+
+    def test_force_replaces_credentials_and_empty_values_are_reprompted(self) -> None:
+        self.env_file.write_text(
+            'GEOFOX_USER="old-user"\nGEOFOX_PASSWORD="old-password"\n',
+            encoding="utf-8",
+        )
+
+        result = self.run_configure(
+            "\nnew-user\n   \nnew-password\n",
+            "--force",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            self.env_file.read_text(encoding="utf-8"),
+            'GEOFOX_USER="new-user"\nGEOFOX_PASSWORD="new-password"\n',
+        )
+        self.assertEqual(result.stderr.count("darf nicht leer sein"), 2)
+
+    def test_incomplete_credentials_require_new_input(self) -> None:
+        self.env_file.write_text(
+            'GEOFOX_USER="old-user"\nGEOFOX_PASSWORD=""\n',
+            encoding="utf-8",
+        )
+
+        result = self.run_configure("new-user\nnew-password\n")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn('GEOFOX_USER="new-user"', self.env_file.read_text())
+
+    def test_aborted_input_and_unknown_option_fail_safely(self) -> None:
+        aborted = self.run_configure("")
+        unknown = self.run_configure("", "--unknown")
+
+        self.assertNotEqual(aborted.returncode, 0)
+        self.assertIn("abgebrochen", aborted.stderr)
+        self.assertFalse(self.env_file.exists())
+        self.assertNotEqual(unknown.returncode, 0)
+        self.assertIn("Unbekannte Option", unknown.stderr)
+
+    def test_aborted_reconfiguration_keeps_existing_file(self) -> None:
+        original = 'GEOFOX_USER="old-user"\nGEOFOX_PASSWORD=""\n'
+        self.env_file.write_text(original, encoding="utf-8")
+
+        result = self.run_configure("")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(self.env_file.read_text(encoding="utf-8"), original)
+        self.assertEqual(list(self.directory.glob("hvv-anzeiger.env.tmp.*")), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_project_artifacts.py
+++ b/tests/test_project_artifacts.py
@@ -25,6 +25,9 @@ class ProjectArtifactTest(unittest.TestCase):
         diagnostic = ROOT / "diagnose.sh"
         self.assertTrue(diagnostic.stat().st_mode & stat.S_IXUSR)
         self.assertTrue(os.access(diagnostic, os.X_OK))
+        credentials = ROOT / "configure-credentials.sh"
+        self.assertTrue(credentials.stat().st_mode & stat.S_IXUSR)
+        self.assertTrue(os.access(credentials, os.X_OK))
         installer_text = installer.read_text(encoding="utf-8")
         self.assertIn('systemctl stop "$SERVICE_NAME"', installer_text)
         self.assertIn('enable --now "$LOG_CLEANUP_TIMER"', installer_text)
@@ -37,6 +40,11 @@ class ProjectArtifactTest(unittest.TestCase):
         )
         self.assertIn("VENV_BACKED_UP", installer_text)
         self.assertIn("INSTALL_SUCCEEDED", installer_text)
+        self.assertIn(
+            'sudo install -m 0755 \\\n'
+            '    "$SOURCE_DIR/configure-credentials.sh"',
+            installer_text,
+        )
 
     def test_systemd_service_uses_protected_environment_file(self) -> None:
         service = (ROOT / "systemd" / "hvv-anzeiger.service").read_text(
@@ -93,6 +101,8 @@ class ProjectArtifactTest(unittest.TestCase):
         self.assertIn("OnCalendar=weekly", timer)
         self.assertIn("Persistent=true", timer)
         self.assertIn("hvv-anzeiger-log-cleanup.timer", diagnostic)
+        self.assertIn('credential_present "GEOFOX_USER"', diagnostic)
+        self.assertIn('credential_present "GEOFOX_PASSWORD"', diagnostic)
 
     def test_readme_documents_every_example_configuration_field(self) -> None:
         readme = (ROOT / "README.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Context

The installer previously created an empty credential file and required a separate manual editor step. That made first-time setup easy to miss and left credential validation outside the tested installation flow.

Related ticket: A-1 (no Jira URL available in the repository context).

## What changed

- Added an interactive credential helper that asks once for the Geofox Application-ID and a hidden password.
- Stores credentials atomically as `root:root` with mode `0600`, without placing secrets in command-line arguments.
- Preserves complete credentials during repeat installations and supports deliberate rotation with `--force`.
- Makes incomplete or aborted input fail safely before the service is started.
- Uses the same completeness check in `diagnose.sh`.
- Documents first-time setup, updates, and credential rotation in the README.
- Adds installation-focused tests and runs the new shell script through Bash syntax checks and ShellCheck in CI.

## Product impact

A fresh Raspberry Pi installation now includes the required Geofox setup in one guided flow. Updates do not prompt again or overwrite working credentials.

## Risks and limitations

- No authenticated Geofox production request was performed, as the real Geofox contract test remains intentionally out of scope.
- Raspberry Pi-specific apt, SPI/GPIO, and systemd behavior still requires the documented on-device acceptance check.
- Credential rotation requires the explicit `--force` flag and a service restart.

## Verification

- 87 unit/integration tests passed on Python 3.12.
- Application coverage remains 100%.
- Ruff, Bash syntax, ShellCheck, and `git diff --check` passed.
- Wheel and source archive built successfully.
- The wheel was installed into a fresh Python 3.12 virtual environment and rendered a 320x240 PNG.
- Locked runtime dependencies installed with hashes; `pip-audit` reported no known vulnerabilities.
- Credential tests cover first setup, hidden output, special characters, mode `0600`, repeat installation, incomplete legacy files, abort safety, and `--force` rotation.

## Review notes

The helper deliberately does not verify credentials against the live Geofox service. It validates safe local storage and lets the existing runtime report rejected credentials without adding an undocumented production API call to installation.

This change has been created with the support of Codex. Please review carefully to confirm that the acceptance criteria are met.