### PR TITLE
A-1: Betriebssicherheit und Nachtabschaltung ergänzen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,11 +87,15 @@ jobs:
         run: bash -n install.sh configure-credentials.sh diagnose.sh
 
       - name: Run ShellCheck
-        run: shellcheck install.sh configure-credentials.sh diagnose.sh
+        run: shellcheck install.sh configure-credentials.sh diagnose.sh tests/install-smoke.sh
 
-      - name: Verify log cleanup systemd units
+      - name: Run transactional installer smoke test
+        run: tests/install-smoke.sh
+
+      - name: Verify systemd units
         run: |
           systemd-analyze verify \
+            systemd/hvv-anzeiger.service \
             systemd/hvv-anzeiger-log-cleanup.service \
             systemd/hvv-anzeiger-log-cleanup.timer
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,8 @@ jobs:
 
       - name: Verify systemd units
         run: |
+          sudo install -d /opt/hvv-anzeiger/.venv/bin
+          sudo ln -s /usr/bin/python3 /opt/hvv-anzeiger/.venv/bin/python
           systemd-analyze verify \
             systemd/hvv-anzeiger.service \
             systemd/hvv-anzeiger-log-cleanup.service \

--- a/README.md
+++ b/README.md
@@ -34,9 +34,16 @@ welcher Haltestelle der Bus abfährt.
   als „sofort“ erscheinen. Die Uhrzeit des letzten Datenstands bleibt sichtbar.
 - Bei getrennter WLAN-Verbindung zeigt die Statusleiste ausdrücklich „KEIN WLAN“
   und, falls vorhanden, die Uhrzeit des letzten erfolgreichen Datenstands.
+- Solange die Systemzeit nach einem Start noch nicht synchronisiert ist, wird
+  „ZEIT NICHT SYNCHRON“ angezeigt und Geofox nicht abgefragt. Dadurch können
+  keine scheinbar plausiblen Abfahrten auf Basis einer falschen Pi-Uhr erscheinen.
+- Standardmäßig wird die Anzeige täglich von 21:00 bis 06:30 Uhr vollständig
+  schwarz geschaltet. Währenddessen pausieren die Geofox-Abrufe. Zeitraum und
+  Aktivierung sind konfigurierbar.
 - Bei wiederholten Fehlern verdoppelt sich der Abstand zwischen den Versuchen bis
   maximal fünf Minuten. Der Anzeigezustand wird trotzdem alle 15 Sekunden geprüft.
-  Nach einem erfolgreichen Abruf gelten auch für die API wieder 15 Sekunden.
+  Eine von Geofox bei HTTP 429 verlangte längere Wartezeit wird bis maximal eine
+  Stunde respektiert. Nach einem erfolgreichen Abruf gelten wieder 15 Sekunden.
 - Schriftarten werden im Arbeitsspeicher wiederverwendet. Ein neues Bild wird nur
   gerendert und über SPI übertragen, wenn sich der sichtbare Inhalt geändert hat.
   Das spart CPU-Zeit und SPI-Übertragungen, ohne die Geofox-Abrufe zu reduzieren.
@@ -51,6 +58,9 @@ welcher Haltestelle der Bus abfährt.
   Journalbestand auf 100 MiB begrenzt.
 - Der systemd-Dienst startet erst nach Netzwerk- und Zeitsynchronisierungs-Targets.
   Das ist wichtig, weil ein Raspberry Pi üblicherweise keine Echtzeituhr besitzt.
+- Ein systemd-Watchdog erwartet spätestens alle 90 Sekunden ein Lebenszeichen.
+  Dadurch wird nicht nur ein abgestürzter, sondern auch ein hängender Prozess
+  automatisch neu gestartet.
 - Der systemd-Dienst darf das Betriebssystem, Benutzerverzeichnisse und den
   Anwendungscode nicht verändern. Schreibzugriff besteht nur auf den lokalen
   Haltestellen-Cache unter `/opt/hvv-anzeiger/var`.
@@ -165,6 +175,13 @@ Die Bezeichnungen auf Display-Modulen unterscheiden sich. `SCK` kann auch `CLK`,
 > GPIO-Pin versorgen, wenn das Modul dafür keinen geeigneten Vorwiderstand oder
 > Treiber besitzt.
 
+Die Nachtabschaltung schreibt ein vollständig schwarzes Bild und pausiert die
+Netzwerkabrufe. Bei der oben gezeigten Verdrahtung bleibt `LED` jedoch an 3,3 V
+und damit elektrisch eingeschaltet. Für eine wirklich ausgeschaltete
+Hintergrundbeleuchtung ist ein zum konkreten Modul passender Transistor- oder
+Treiberbaustein erforderlich; die LED sollte nicht ungeprüft direkt an einen
+GPIO-Pin angeschlossen werden.
+
 ## Erwarteter Ressourcenverbrauch auf dem Pi Zero 2 W
 
 Die folgenden Werte sind realistische Orientierungswerte, aber noch keine Messung
@@ -177,7 +194,7 @@ WLAN-Qualität und Größe der Geofox-Antwort beeinflussen die tatsächlichen We
 | CPU | meist niedriger einstelliger Prozentbereich im zeitlichen Mittel, mit kurzen Spitzen beim API-Abruf und Rendern | die vier Kerne werden nicht dauerhaft belastet; andere kleine Dienste können parallel laufen |
 | Bildspeicher | 230.400 Byte pro 320 × 240-RGB-Bild, zeitweise wenige Bildpuffer | weniger als einige MiB; für den Pi unkritisch |
 | SPI | 230.400 Byte pro vollständig übertragenem Bild | bei unveränderter Anzeige meist nur etwa einmal pro Minute statt viermal; bei jeder sichtbaren Änderung sofort |
-| Netzwerk | 240 Geofox-Abrufe pro Stunde; typischerweise wenige MiB pro Stunde | geringes Datenvolumen, aber dauerhaftes WLAN ist erforderlich; die Antwortgröße bestimmt den exakten Wert |
+| Netzwerk | bis zu 240 Geofox-Abrufe pro aktiver Stunde; während der Standard-Nachtabschaltung keine | typischerweise wenige MiB pro aktiver Stunde; die Antwortgröße bestimmt den exakten Wert |
 | Installation | grob 50–120 MiB für Anwendung, virtuelle Python-Umgebung und Bibliotheken | die Paket-Caches des Betriebssystems können zusätzlich Speicherplatz belegen |
 
 Der größte dauerhafte Stromverbrauch entsteht voraussichtlich durch Raspberry Pi,
@@ -189,7 +206,9 @@ kontrolliert werden.
 Die Anwendung vermeidet unnötige Arbeit:
 
 - Geofox wird weiterhin alle 15 Sekunden abgefragt, damit Echtzeitänderungen schnell
-  sichtbar werden.
+  sichtbar werden. In der standardmäßigen Nachtabschaltung von 21:00 bis 06:30
+  entfallen die Abrufe vollständig; 240 Abrufe pro Stunde sind deshalb der
+  Höchstwert während der aktiven Anzeigezeit.
 - Solange Uhrzeit, Abfahrten und Statushinweis gleich bleiben, entfallen Rendering
   und SPI-Transfer vollständig.
 - Geladene Schriftarten werden wiederverwendet.
@@ -267,9 +286,11 @@ Das Skript:
   interaktiv ab; das Passwort bleibt bei der Eingabe unsichtbar,
 - übernimmt eine vorhandene `config.json` und vollständige Zugangsdaten bei
   späteren Updates unverändert,
-- stoppt bei einer Wiederholungsinstallation zuerst den laufenden Dienst,
-- sichert die bisherige Python-Umgebung und stellt sie bei einem Installationsfehler
-  automatisch wieder her,
+- baut Programmcode und Python-Umgebung zuerst vollständig in einem separaten
+  Verzeichnis auf und rendert dort ein Testbild,
+- stoppt den laufenden Dienst erst für die kurze Umschaltung,
+- stellt bei einem Installations- oder Startfehler die komplette vorherige
+  Anwendung einschließlich Python-Umgebung und systemd-Units wieder her,
 - aktiviert die Netzwerk-Zeitsynchronisierung,
 - legt den nicht interaktiven Systembenutzer `hvv-anzeiger` an,
 - schützt Programmcode und Konfiguration als `root:root` und gibt dem Dienst nur
@@ -277,13 +298,20 @@ Das Skript:
 - installiert ausschließlich die in `requirements.txt` festgelegten Pakete mit
   geprüften SHA-256-Hashes,
 - aktiviert die wöchentliche Journal-Bereinigung,
-- aktiviert den Autostart.
+- aktiviert den Autostart und den 90-Sekunden-Watchdog,
+- zeigt zum Abschluss einen kompakten Statusblock für Dienst, Autostart,
+  Log-Bereinigung und SPI.
 
 Die Zugangsdaten werden weder als Kommandozeilenparameter noch im Repository
 gespeichert. Der Installer schreibt sie atomar mit den Dateirechten `0600` nach
 `/etc/hvv-anzeiger.env`. Bricht die Eingabe ab oder bleibt ein Wert leer, startet
 der Dienst nicht mit einer unvollständigen Konfiguration. Nach der erstmaligen
 SPI-Aktivierung sollte der Raspberry Pi neu gestartet werden.
+
+Der laufende Dienst wird erst beendet, nachdem Abhängigkeiten, Paketinstallation
+und lokales Rendern der neuen Version erfolgreich waren. Schlägt der anschließende
+Start fehl, wird die vorherige Version automatisch zurückgeschaltet und erneut
+gestartet.
 
 ### Manuelle Installation
 
@@ -382,7 +410,7 @@ cd /opt/hvv-anzeiger
 set -a
 . /etc/hvv-anzeiger.env
 set +a
-.venv/bin/hvv-anzeiger --config config.json --once
+.venv/bin/python -m hvv_display --config config.json --once
 ```
 
 Die Beispielkonfiguration enthält die geprüften IDs `Master:82039` für
@@ -395,13 +423,13 @@ beim entsprechenden Eintrag in `config.json` ergänzen.
 Für einen Test ohne angeschlossenes Display kann eine PNG-Datei geschrieben werden:
 
 ```bash
-.venv/bin/hvv-preview preview.png
+.venv/bin/python -m hvv_display.preview preview.png
 ```
 
 Oder mit echten API-Daten:
 
 ```bash
-.venv/bin/hvv-anzeiger --config config.json --once --output preview.png
+.venv/bin/python -m hvv_display --config config.json --once --output preview.png
 ```
 
 ### 5. Automatischen Start einrichten
@@ -473,6 +501,25 @@ weggelassen werden; dann gelten die folgenden Defaults aus dem Programmcode.
 | `display.bus_speed_hz` | `16000000` | SPI-Takt in Hertz; muss größer als 0 sein |
 | `display.bgr` | `false` | auf `true` setzen, falls Rot und Blau vertauscht sind |
 
+### Nachtabschaltungs-Defaults
+
+| Feld | Default | Bedeutung und Grenze |
+|---|---:|---|
+| `night_shutdown.enabled` | `true` | schaltet das Display im konfigurierten Zeitraum schwarz und pausiert Geofox; mit `false` vollständig deaktivierbar |
+| `night_shutdown.start` | `"21:00"` | Beginn im lokalen Hamburger Zeitformat `HH:MM` |
+| `night_shutdown.end` | `"06:30"` | Ende im lokalen Hamburger Zeitformat `HH:MM`; muss sich vom Beginn unterscheiden |
+
+Zeiträume über Mitternacht und innerhalb eines Tages werden unterstützt. Beginn
+ist eingeschlossen, das Ende ausgeschlossen. Für einen durchgehenden Betrieb:
+
+```json
+"night_shutdown": {
+  "enabled": false,
+  "start": "21:00",
+  "end": "06:30"
+}
+```
+
 ### Haltestellen-Defaults
 
 | Feld | Default | Bedeutung und Grenze |
@@ -523,10 +570,16 @@ python3.11 -m venv .venv
 .venv/bin/coverage run -m unittest discover -s tests -v
 .venv/bin/coverage report
 .venv/bin/pip-audit --requirement requirements.txt --disable-pip
-.venv/bin/hvv-preview preview.png
+.venv/bin/python -m hvv_display.preview preview.png
 bash -n install.sh configure-credentials.sh diagnose.sh
-shellcheck install.sh configure-credentials.sh diagnose.sh
+shellcheck install.sh configure-credentials.sh diagnose.sh tests/install-smoke.sh
 ```
+
+`tests/install-smoke.sh` läuft in GitHub Actions auf Ubuntu. Es führt eine
+vollständige Erstinstallation mit isolierten Systempfaden und Kommando-Doubles
+für Raspberry-Pi-Systembefehle aus. Anschließend erzwingt es einen fehlgeschlagenen
+Dienststart und prüft, dass Anwendung, Zugangsdaten und systemd-Units vollständig
+auf den vorherigen Stand zurückgesetzt werden.
 
 Die automatisierten Tests prüfen unter anderem:
 
@@ -538,6 +591,8 @@ Die automatisierten Tests prüfen unter anderem:
 - eine dokumentationsnahe, anonymisierte Geofox-Beispielantwort vom API-Eingang
   bis zum gerenderten Displaybild,
 - Herkunftskennzeichnung pro Haltestelle und begrenztes Fehler-Backoff,
+- Geofox-`Retry-After`, Nachtfenster über Mitternacht und das Pausieren der API,
+- Zeitstatus vor dem ersten Geofox-Abruf und Watchdog-Lebenszeichen,
 - stündlich begrenztes Erfolgs-Logging, gehärteten systemd-Dienst und
   wiederherstellbare Python-Installation,
 - HTTPS-/Host-Prüfung, einzeilige externe Fehlertexte, den dedizierten
@@ -550,12 +605,14 @@ Die automatisierten Tests prüfen unter anderem:
 - Screenshot, Installationsskript, Pi-Diagnose und systemd-Konfiguration.
 - einmalige, verdeckte Zugangsdatenabfrage, sichere Dateirechte, Wiederverwendung
   vorhandener Zugangsdaten und bewusste Rotation mit `--force`.
+- vollständige isolierte Erstinstallation und transaktionales Rollback bei einem
+  simulierten Dienstfehler.
 
 GitHub Actions führt diese Prüfungen nach jedem Push und für jeden Pull Request mit
 Python 3.10, 3.11 und 3.13 aus. Zusätzlich werden Ruff einschließlich seiner
 Security-Regeln, eine Mindest-Testabdeckung von 100 Prozent, `pip-audit`, beide
 Shell-Skripte mit Bash und ShellCheck, ein Vorschaubild und das installierbare
-Python-Paket geprüft.
+Python-Paket sowie der transaktionale Installer-Smoke-Test geprüft.
 
 Alle direkten und transitiven Laufzeitabhängigkeiten sind mit Prüfsummen in
 `requirements.txt` festgeschrieben. `requirements-dev.txt` ergänzt die ebenfalls
@@ -578,6 +635,12 @@ Nach Installation, Zugangsdaten und Neustart:
    Aktualisierung zurückkehren.
 7. Den Raspberry Pi neu starten und mit `systemctl status hvv-anzeiger` prüfen,
    dass die Anzeige ohne manuelles Eingreifen wieder läuft.
+8. Für einen Nachtfunktionstest `night_shutdown.start` kurz auf wenige Minuten vor
+   die aktuelle Zeit und `night_shutdown.end` auf wenige Minuten danach setzen:
+   Das Bild muss schwarz werden und nach Ende des Fensters selbstständig
+   zurückkehren. Anschließend die gewünschten Zeiten wiederherstellen.
+9. `systemctl show hvv-anzeiger -p Type -p WatchdogUSec` muss `Type=notify` und
+   einen Watchdog-Wert von 90 Sekunden anzeigen.
 
 ## Technischer Hintergrund
 
@@ -585,12 +648,20 @@ Die Anwendung verwendet die Geofox-Methode
 `POST /gti/public/departureList` mit API-Version 63 und `useRealtime: true`.
 Die Signatur ist Base64-codiertes HMAC-SHA1 über den exakten UTF-8-JSON-Body.
 Jede Anfrage bekommt eine eigene `X-TraceId`, die bei Fehlern im Log steht.
+Bei HTTP 429 wird ein gültiger `Retry-After`-Wert respektiert und aus
+Sicherheitsgründen auf höchstens eine Stunde begrenzt.
 
 Das Display wird über `luma.lcd` angesteuert. Die Oberfläche selbst wird mit Pillow
 als 320 × 240 Pixel großes RGB-Bild erzeugt und anschließend vollständig auf das
 ILI9341 übertragen. Bereits geladene Schriftarten werden zwischengespeichert.
 Ein Bild wird nur neu erzeugt und übertragen, wenn sich sein sichtbarer Inhalt
 gegenüber dem vorherigen Bild geändert hat.
+
+Vor dem ersten API-Abruf prüft die Anwendung den Synchronisationsmarker von
+`systemd-timesyncd` und ersatzweise `timedatectl`. Nach der ersten bestätigten
+Synchronisierung gilt die Uhr für die Laufzeit des Prozesses als verwendbar.
+Während des Nachtfensters wird genau einmal ein schwarzes Bild übertragen; weitere
+Renderings und Geofox-Anfragen entfallen bis zum Ende des Zeitraums.
 
 Der Dienst läuft als nicht interaktiver Benutzer `hvv-anzeiger` mit
 systemd-Schutzmechanismen wie `NoNewPrivileges` und einem schreibgeschützten
@@ -600,3 +671,8 @@ Schreibausnahme für den Haltestellen-Cache. Ein bewusstes RAM-Limit ist nicht
 gesetzt: Die dokumentierten Messbefehle sollten zuerst auf dem konkreten Pi
 ausgeführt werden, damit ein zu knapp angesetztes Limit nicht unnötig zu
 Neustarts führt.
+
+Der Dienst verwendet `Type=notify` und meldet Bereitschaft sowie regelmäßige
+Watchdog-Lebenszeichen direkt über den von systemd bereitgestellten Unix-Socket.
+Bleibt ein Lebenszeichen länger als 90 Sekunden aus, beendet und startet systemd
+den Prozess neu.

--- a/config.example.json
+++ b/config.example.json
@@ -17,6 +17,11 @@
     "bus_speed_hz": 16000000,
     "bgr": false
   },
+  "night_shutdown": {
+    "enabled": true,
+    "start": "21:00",
+    "end": "06:30"
+  },
   "stations": [
     {
       "name": "Weistritzstraße",

--- a/diagnose.sh
+++ b/diagnose.sh
@@ -78,8 +78,15 @@ else
   fail "timedatectl wurde nicht gefunden."
 fi
 
-if [[ -x "$APP_DIR/.venv/bin/hvv-preview" ]]; then
-  if "$APP_DIR/.venv/bin/hvv-preview" "$PREVIEW_FILE"; then
+if [[ -x "$APP_DIR/.venv/bin/python" ]]; then
+  if "$APP_DIR/.venv/bin/python" -c \
+    'import sys; from hvv_display.config import load_config; load_config(sys.argv[1])' \
+    "$APP_DIR/config.json"; then
+    pass "Die installierte Konfiguration ist gültig."
+  else
+    fail "Die installierte config.json ist ungültig."
+  fi
+  if "$APP_DIR/.venv/bin/python" -m hvv_display.preview "$PREVIEW_FILE"; then
     pass "Die lokale Display-Vorschau wurde erfolgreich gerendert."
     rm -f "$PREVIEW_FILE"
   else
@@ -106,6 +113,19 @@ if systemctl is-active --quiet "$SERVICE_NAME"; then
   pass "Der Dienst läuft."
 else
   fail "Der Dienst läuft nicht."
+fi
+
+SERVICE_TYPE="$(
+  systemctl show "$SERVICE_NAME" --property=Type --value 2>/dev/null
+)"
+WATCHDOG_USEC="$(
+  systemctl show "$SERVICE_NAME" --property=WatchdogUSec --value 2>/dev/null
+)"
+if [[ "$SERVICE_TYPE" == "notify" && "$WATCHDOG_USEC" != "0" &&
+  -n "$WATCHDOG_USEC" ]]; then
+  pass "Der systemd-Watchdog ist aktiviert (${WATCHDOG_USEC})."
+else
+  fail "Der systemd-Watchdog ist nicht korrekt aktiviert."
 fi
 
 if systemctl is-enabled --quiet "$LOG_CLEANUP_TIMER" &&

--- a/hvv_display/clock.py
+++ b/hvv_display/clock.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Callable
+from datetime import datetime, time
+from pathlib import Path
+
+SYSTEMD_SYNC_MARKER = Path("/run/systemd/timesync/synchronized")
+
+
+def time_is_synchronized(
+    *,
+    marker: Path = SYSTEMD_SYNC_MARKER,
+    run: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> bool | None:
+    """Return the system clock sync state, or None when it cannot be determined."""
+    if marker.exists():
+        return True
+    try:
+        result = run(
+            ["timedatectl", "show", "--property=NTPSynchronized", "--value"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+    except (FileNotFoundError, OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    value = result.stdout.strip().lower()
+    if value == "yes":
+        return True
+    if value == "no":
+        return False
+    return None
+
+
+def in_night_shutdown(now: datetime, start: time, end: time) -> bool:
+    """Return whether a local time falls inside an overnight or daytime window."""
+    current = now.timetz().replace(tzinfo=None)
+    if start < end:
+        return start <= current < end
+    return current >= start or current < end

--- a/hvv_display/config.py
+++ b/hvv_display/config.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import dataclass
+from datetime import time
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlsplit
@@ -36,9 +38,17 @@ class DisplayConfig:
 
 
 @dataclass(frozen=True)
+class NightShutdownConfig:
+    enabled: bool
+    start: time
+    end: time
+
+
+@dataclass(frozen=True)
 class AppConfig:
     api: ApiConfig
     display: DisplayConfig
+    night_shutdown: NightShutdownConfig
     stations: tuple[Station, ...]
 
 
@@ -77,6 +87,13 @@ def _geofox_base_url(value: Any) -> str:
     return base_url
 
 
+def _clock_time(value: Any, field: str) -> time:
+    raw = str(value)
+    if re.fullmatch(r"(?:[01]\d|2[0-3]):[0-5]\d", raw) is None:
+        raise ConfigError(f"{field} muss als HH:MM angegeben werden")
+    return time.fromisoformat(raw)
+
+
 def load_config(path: str | Path) -> AppConfig:
     config_path = Path(path)
     try:
@@ -89,6 +106,7 @@ def load_config(path: str | Path) -> AppConfig:
     try:
         api_raw = raw["api"]
         display_raw = raw["display"]
+        night_raw = raw.get("night_shutdown", {})
         stations_raw = raw["stations"]
     except (KeyError, TypeError) as exc:
         raise ConfigError("Konfiguration benötigt api, display und stations") from exc
@@ -127,6 +145,25 @@ def load_config(path: str | Path) -> AppConfig:
     if display.bus_speed_hz <= 0:
         raise ConfigError("display.bus_speed_hz muss größer als 0 sein")
 
+    night_shutdown = NightShutdownConfig(
+        enabled=_boolean(
+            night_raw.get("enabled", True),
+            "night_shutdown.enabled",
+        ),
+        start=_clock_time(
+            night_raw.get("start", "21:00"),
+            "night_shutdown.start",
+        ),
+        end=_clock_time(
+            night_raw.get("end", "06:30"),
+            "night_shutdown.end",
+        ),
+    )
+    if night_shutdown.start == night_shutdown.end:
+        raise ConfigError(
+            "night_shutdown.start und night_shutdown.end müssen verschieden sein"
+        )
+
     stations: list[Station] = []
     for index, station_raw in enumerate(stations_raw):
         station_name = str(_required(station_raw, "name", f"stations[{index}]"))
@@ -161,4 +198,9 @@ def load_config(path: str | Path) -> AppConfig:
     labels = [station.label for station in stations]
     if len(labels) != len(set(labels)):
         raise ConfigError("stations[].label muss pro Haltestelle eindeutig sein")
-    return AppConfig(api=api, display=display, stations=tuple(stations))
+    return AppConfig(
+        api=api,
+        display=display,
+        night_shutdown=night_shutdown,
+        stations=tuple(stations),
+    )

--- a/hvv_display/geofox.py
+++ b/hvv_display/geofox.py
@@ -5,6 +5,7 @@ import hashlib
 import hmac
 import json
 import logging
+import math
 import threading
 import time
 import unicodedata
@@ -13,6 +14,7 @@ import urllib.request
 import uuid
 from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
+from email.utils import parsedate_to_datetime
 from typing import Any
 from urllib.parse import urlsplit
 from zoneinfo import ZoneInfo
@@ -22,10 +24,40 @@ from .models import Departure, Route, Station
 LOG = logging.getLogger(__name__)
 HAMBURG_TZ = ZoneInfo("Europe/Berlin")
 MAX_RESPONSE_BYTES = 1024 * 1024
+MAX_RETRY_AFTER_SECONDS = 3600
 
 
 class GeofoxError(RuntimeError):
     """A safe, user-displayable Geofox error."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        retry_after_seconds: int | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.retry_after_seconds = retry_after_seconds
+
+
+def _retry_after_seconds(value: Any, *, now: datetime | None = None) -> int | None:
+    if value is None:
+        return None
+    raw = str(value).strip()
+    try:
+        seconds = int(raw)
+    except ValueError:
+        try:
+            retry_at = parsedate_to_datetime(raw)
+            if retry_at.tzinfo is None:
+                retry_at = retry_at.replace(tzinfo=timezone.utc)
+            reference = now or datetime.now(timezone.utc)
+            seconds = math.ceil((retry_at - reference).total_seconds())
+        except (TypeError, ValueError, OverflowError):
+            return None
+    if seconds <= 0:
+        return None
+    return min(seconds, MAX_RETRY_AFTER_SECONDS)
 
 
 def normalize(value: str) -> str:
@@ -148,7 +180,12 @@ class GeofoxClient:
             if exc.code == 401:
                 raise GeofoxError("Geofox-Zugangsdaten wurden abgelehnt") from exc
             if exc.code == 429:
-                raise GeofoxError("Geofox-Anfragelimit erreicht") from exc
+                raise GeofoxError(
+                    "Geofox-Anfragelimit erreicht",
+                    retry_after_seconds=_retry_after_seconds(
+                        exc.headers.get("Retry-After")
+                    ),
+                ) from exc
             raise GeofoxError(f"Geofox antwortet mit HTTP {exc.code}") from exc
         except (urllib.error.URLError, TimeoutError, OSError) as exc:
             LOG.error("Geofox nicht erreichbar, Trace-ID %s", trace_id)

--- a/hvv_display/main.py
+++ b/hvv_display/main.py
@@ -9,12 +9,17 @@ import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+from PIL import Image
+
+from .clock import in_night_shutdown
+from .clock import time_is_synchronized as clock_is_synchronized
 from .config import ConfigError, load_config
 from .geofox import HAMBURG_TZ, GeofoxClient, GeofoxError
 from .hardware import Ili9341Display
 from .models import Departure
 from .network import wifi_connected
-from .render import board_state_key, render_board
+from .render import HEIGHT, WIDTH, board_state_key, render_board
+from .service import SystemdNotifier
 from .stations import resolve_stations
 
 LOG = logging.getLogger(__name__)
@@ -22,14 +27,19 @@ MAX_REFRESH_BACKOFF_SECONDS = 300
 SUCCESS_HEARTBEAT_SECONDS = 3600
 
 
-def refresh_delay(refresh_seconds: int, consecutive_failures: int) -> int:
+def refresh_delay(
+    refresh_seconds: int,
+    consecutive_failures: int,
+    retry_after_seconds: int | None = None,
+) -> int:
     """Return a bounded retry delay; the first failure doubles the normal interval."""
     if consecutive_failures <= 0:
         return refresh_seconds
-    return min(
+    backoff = min(
         MAX_REFRESH_BACKOFF_SECONDS,
         refresh_seconds * (2 ** min(consecutive_failures, 5)),
     )
+    return max(backoff, retry_after_seconds or 0)
 
 
 def log_success(
@@ -100,30 +110,40 @@ def update_board(
     previous_state: tuple[object, ...] | None,
     output: str | None,
     display: Ili9341Display | None,
+    time_is_synchronized: bool | None = True,
+    night_shutdown: bool = False,
 ) -> tuple[object, ...]:
     """Render and transfer a frame only when its visible content changed."""
-    current_state = board_state_key(
-        departures,
-        now=now,
-        last_updated=last_updated,
-        stale=stale,
-        error_message=error_message,
-        wifi_is_connected=wifi_is_connected,
-        max_rows=max_rows,
-    )
+    if night_shutdown:
+        current_state: tuple[object, ...] = ("night-shutdown",)
+    else:
+        current_state = board_state_key(
+            departures,
+            now=now,
+            last_updated=last_updated,
+            stale=stale,
+            error_message=error_message,
+            wifi_is_connected=wifi_is_connected,
+            max_rows=max_rows,
+            time_is_synchronized=time_is_synchronized,
+        )
     if current_state == previous_state:
         LOG.debug("Displayinhalt unverändert; Aktualisierung übersprungen")
         return current_state
 
-    image = render_board(
-        departures,
-        now=now,
-        last_updated=last_updated,
-        stale=stale,
-        error_message=error_message,
-        wifi_is_connected=wifi_is_connected,
-        max_rows=max_rows,
-    )
+    if night_shutdown:
+        image = Image.new("RGB", (WIDTH, HEIGHT), "black")
+    else:
+        image = render_board(
+            departures,
+            now=now,
+            last_updated=last_updated,
+            stale=stale,
+            error_message=error_message,
+            wifi_is_connected=wifi_is_connected,
+            max_rows=max_rows,
+            time_is_synchronized=time_is_synchronized,
+        )
     if output:
         output_path = Path(output)
         output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -137,6 +157,7 @@ def update_board(
 
 def run() -> int:
     args = _arguments()
+    notifier = SystemdNotifier()
     try:
         config = load_config(args.config)
         client = GeofoxClient(
@@ -146,7 +167,6 @@ def run() -> int:
             version=config.api.version,
             timeout=config.api.request_timeout_seconds,
         )
-        stations = resolve_stations(client, config.stations, args.cache)
         display = None if args.output else Ili9341Display(config.display)
     except (ConfigError, GeofoxError, RuntimeError) as exc:
         LOG.error("%s", exc)
@@ -162,6 +182,7 @@ def run() -> int:
     signal.signal(signal.SIGINT, stop)
 
     latest: list[Departure] = []
+    stations = None
     last_updated: datetime | None = None
     consecutive_failures = 0
     last_error: str | None = None
@@ -169,11 +190,38 @@ def run() -> int:
     wifi_interface = os.environ.get("HVV_WIFI_INTERFACE", "wlan0")
     last_board_state: tuple[object, ...] | None = None
     last_success_heartbeat_at: float | None = None
+    clock_confirmed = False
+    notifier.ready()
     while not stopped:
         now = datetime.now(HAMBURG_TZ)
         current_monotonic = time.monotonic()
-        if current_monotonic >= next_api_attempt_at:
+        notifier.ping_if_due(current_monotonic)
+        sync_probe = True if clock_confirmed else clock_is_synchronized()
+        if sync_probe is True:
+            clock_confirmed = True
+        clock_ready = clock_confirmed
+        night_active = (
+            clock_ready
+            and config.night_shutdown.enabled
+            and in_night_shutdown(
+                now,
+                config.night_shutdown.start,
+                config.night_shutdown.end,
+            )
+        )
+
+        if (
+            clock_ready
+            and not night_active
+            and current_monotonic >= next_api_attempt_at
+        ):
             try:
+                if stations is None:
+                    stations = resolve_stations(
+                        client,
+                        config.stations,
+                        args.cache,
+                    )
                 latest = client.departure_list(
                     stations,
                     now=now,
@@ -191,42 +239,55 @@ def run() -> int:
             except GeofoxError as exc:
                 last_error = str(exc)
                 consecutive_failures += 1
+                retry_after_seconds = exc.retry_after_seconds
                 LOG.warning("Aktualisierung fehlgeschlagen: %s", exc)
+            else:
+                retry_after_seconds = None
 
             api_delay = refresh_delay(
                 config.api.refresh_seconds,
                 consecutive_failures,
+                retry_after_seconds,
             )
             next_api_attempt_at = time.monotonic() + api_delay
             if consecutive_failures:
                 LOG.info("Nächster Geofox-Versuch in %d Sekunden", api_delay)
 
-        wifi_state = wifi_connected(wifi_interface)
+        wifi_state = None if night_active else wifi_connected(wifi_interface)
+        visible_error = last_error
+        if not clock_ready:
+            visible_error = "Systemzeit ist noch nicht synchronisiert"
         visible_departures = departures_for_display(
             latest,
             now=now,
             last_updated=last_updated,
-            stale=last_error is not None,
+            stale=visible_error is not None,
             max_stale_age_minutes=config.api.max_stale_age_minutes,
         )
         last_board_state = update_board(
             visible_departures,
             now=now,
             last_updated=last_updated,
-            stale=last_error is not None,
-            error_message=last_error,
+            stale=visible_error is not None,
+            error_message=visible_error,
             wifi_is_connected=wifi_state,
             max_rows=config.api.max_departures,
             previous_state=last_board_state,
             output=args.output,
             display=display,
+            time_is_synchronized=clock_ready,
+            night_shutdown=night_active,
         )
 
         if args.once:
-            return 0 if last_error is None else 1
+            return 0 if clock_ready and last_error is None else 1
         deadline = time.monotonic() + config.api.refresh_seconds
-        while not stopped and time.monotonic() < deadline:
-            time.sleep(min(1.0, deadline - time.monotonic()))
+        while not stopped:
+            sleep_now = time.monotonic()
+            if sleep_now >= deadline:
+                break
+            notifier.ping_if_due(sleep_now)
+            time.sleep(min(1.0, deadline - sleep_now))
     return 0
 
 

--- a/hvv_display/render.py
+++ b/hvv_display/render.py
@@ -107,7 +107,10 @@ def _status_text(
     wifi_is_connected: bool | None,
     stale: bool,
     last_updated: datetime | None,
+    time_is_synchronized: bool | None = True,
 ) -> str | None:
+    if time_is_synchronized is False:
+        return "ZEIT NICHT SYNCHRON"
     if wifi_is_connected is False:
         label = "KEIN WLAN"
         if last_updated:
@@ -130,6 +133,7 @@ def board_state_key(
     error_message: str | None,
     wifi_is_connected: bool | None,
     max_rows: int,
+    time_is_synchronized: bool | None = True,
 ) -> tuple[object, ...]:
     """Describe only visible state so unchanged frames need not be redrawn."""
     visible_departures = tuple(
@@ -156,6 +160,7 @@ def board_state_key(
         bool(error_message) if not visible_departures else False,
         _status_text(
             wifi_is_connected=wifi_is_connected,
+            time_is_synchronized=time_is_synchronized,
             stale=stale,
             last_updated=last_updated,
         ),
@@ -171,6 +176,7 @@ def render_board(
     error_message: str | None = None,
     wifi_is_connected: bool | None = None,
     max_rows: int = 5,
+    time_is_synchronized: bool | None = True,
 ) -> Image.Image:
     image = Image.new("RGB", (WIDTH, HEIGHT), BLACK)
     draw = ImageDraw.Draw(image)
@@ -256,6 +262,7 @@ def render_board(
 
     status_label = _status_text(
         wifi_is_connected=wifi_is_connected,
+        time_is_synchronized=time_is_synchronized,
         stale=stale,
         last_updated=last_updated,
     )

--- a/hvv_display/service.py
+++ b/hvv_display/service.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import os
+import socket
+from collections.abc import Callable, Mapping
+
+
+class SystemdNotifier:
+    """Send readiness and watchdog notifications without an extra dependency."""
+
+    def __init__(
+        self,
+        *,
+        environment: Mapping[str, str] = os.environ,
+        process_id: int | None = None,
+        socket_factory: Callable[..., socket.socket] = socket.socket,
+    ) -> None:
+        notify_socket = environment.get("NOTIFY_SOCKET", "")
+        watchdog_pid = environment.get("WATCHDOG_PID")
+        current_pid = process_id if process_id is not None else os.getpid()
+        if watchdog_pid and watchdog_pid != str(current_pid):
+            notify_socket = ""
+
+        self._address = (
+            "\0" + notify_socket[1:] if notify_socket.startswith("@") else notify_socket
+        )
+        self._socket_factory = socket_factory
+        self._last_watchdog_at: float | None = None
+        try:
+            watchdog_seconds = int(environment.get("WATCHDOG_USEC", "0")) / 1_000_000
+        except ValueError:
+            watchdog_seconds = 0
+        self._watchdog_interval = (
+            max(1.0, watchdog_seconds / 2) if watchdog_seconds > 0 else None
+        )
+
+    def _send(self, message: str) -> bool:
+        if not self._address:
+            return False
+        notifier_socket = self._socket_factory(socket.AF_UNIX, socket.SOCK_DGRAM)
+        try:
+            notifier_socket.sendto(message.encode("utf-8"), self._address)
+        except OSError:
+            return False
+        finally:
+            notifier_socket.close()
+        return True
+
+    def ready(self) -> bool:
+        return self._send("READY=1")
+
+    def ping_if_due(self, now_monotonic: float) -> bool:
+        if self._watchdog_interval is None:
+            return False
+        if (
+            self._last_watchdog_at is not None
+            and now_monotonic - self._last_watchdog_at < self._watchdog_interval
+        ):
+            return False
+        if not self._send("WATCHDOG=1"):
+            return False
+        self._last_watchdog_at = now_monotonic
+        return True

--- a/install.sh
+++ b/install.sh
@@ -2,35 +2,104 @@
 
 set -Eeuo pipefail
 
-APP_DIR="/opt/hvv-anzeiger"
-ENV_FILE="/etc/hvv-anzeiger.env"
+APP_DIR="${HVV_APP_DIR:-/opt/hvv-anzeiger}"
+ENV_FILE="${HVV_ENV_FILE:-/etc/hvv-anzeiger.env}"
+SYSTEMD_DIR="${HVV_SYSTEMD_DIR:-/etc/systemd/system}"
 SERVICE_NAME="hvv-anzeiger"
+LOG_CLEANUP_SERVICE="hvv-anzeiger-log-cleanup.service"
 LOG_CLEANUP_TIMER="hvv-anzeiger-log-cleanup.timer"
 SOURCE_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 APP_USER="hvv-anzeiger"
 APP_GROUP="hvv-anzeiger"
+BACKUP_DIR="${APP_DIR}.previous"
+STAGING_DIR=""
+UNIT_BACKUP_DIR=""
+ENV_BACKUP_DIR=""
 SERVICE_WAS_ACTIVE=0
+SWITCHED=0
 INSTALL_SUCCEEDED=0
-VENV_BACKED_UP=0
-VENV_BACKUP="${APP_DIR}/.venv.previous"
-
-cleanup() {
-  if ((INSTALL_SUCCEEDED == 0 && VENV_BACKED_UP == 1)); then
-    sudo rm -rf "${APP_DIR}/.venv"
-    sudo mv "$VENV_BACKUP" "${APP_DIR}/.venv"
-  fi
-  if ((INSTALL_SUCCEEDED == 0 && SERVICE_WAS_ACTIVE == 1)); then
-    echo "Installation fehlgeschlagen; vorherigen Dienst wieder starten." >&2
-    sudo systemctl start "$SERVICE_NAME" || true
-  fi
-}
-trap cleanup EXIT
 
 fail() {
   echo "Fehler: $*" >&2
   exit 1
 }
 
+safe_remove_tree() {
+  local target="$1"
+  [[ -n "$target" && "$target" = /* && "$target" != "/" ]] ||
+    fail "Unsicherer Löschpfad abgelehnt: ${target}"
+  sudo rm -rf -- "$target"
+}
+
+backup_unit() {
+  local unit="$1"
+  if [[ -e "${SYSTEMD_DIR}/${unit}" ]]; then
+    sudo cp -p "${SYSTEMD_DIR}/${unit}" "${UNIT_BACKUP_DIR}/${unit}"
+  else
+    sudo touch "${UNIT_BACKUP_DIR}/${unit}.missing"
+  fi
+}
+
+restore_units() {
+  local unit
+  for unit in "$SERVICE_NAME.service" "$LOG_CLEANUP_SERVICE" "$LOG_CLEANUP_TIMER"; do
+    if [[ -e "${UNIT_BACKUP_DIR}/${unit}.missing" ]]; then
+      sudo rm -f -- "${SYSTEMD_DIR}/${unit}"
+    elif [[ -e "${UNIT_BACKUP_DIR}/${unit}" ]]; then
+      sudo cp -p "${UNIT_BACKUP_DIR}/${unit}" "${SYSTEMD_DIR}/${unit}"
+    fi
+  done
+  sudo systemctl daemon-reload || true
+}
+
+restore_credentials() {
+  if [[ -e "${ENV_BACKUP_DIR}/credentials.missing" ]]; then
+    sudo rm -f -- "$ENV_FILE"
+  elif [[ -e "${ENV_BACKUP_DIR}/credentials" ]]; then
+    sudo cp -p "${ENV_BACKUP_DIR}/credentials" "$ENV_FILE"
+  fi
+}
+
+cleanup() {
+  local exit_code=$?
+  if ((INSTALL_SUCCEEDED == 0)); then
+    set +e
+    if ((SWITCHED == 1)); then
+      sudo systemctl stop "$SERVICE_NAME"
+      if [[ -e "$APP_DIR" ]]; then
+        safe_remove_tree "$APP_DIR"
+      fi
+      if [[ -e "$BACKUP_DIR" ]]; then
+        sudo mv "$BACKUP_DIR" "$APP_DIR"
+      fi
+    elif [[ -n "$STAGING_DIR" && -e "$STAGING_DIR" ]]; then
+      safe_remove_tree "$STAGING_DIR"
+    fi
+    if [[ -n "$UNIT_BACKUP_DIR" && -d "$UNIT_BACKUP_DIR" ]]; then
+      restore_units
+    fi
+    if [[ -n "$ENV_BACKUP_DIR" && -d "$ENV_BACKUP_DIR" ]]; then
+      restore_credentials
+    fi
+    if ((SERVICE_WAS_ACTIVE == 1)) && [[ -d "$APP_DIR" ]]; then
+      echo "Installation fehlgeschlagen; vorherige Version wird gestartet." >&2
+      sudo systemctl start "$SERVICE_NAME" || true
+    fi
+  fi
+  if [[ -n "$UNIT_BACKUP_DIR" && -e "$UNIT_BACKUP_DIR" ]]; then
+    safe_remove_tree "$UNIT_BACKUP_DIR"
+  fi
+  if [[ -n "$ENV_BACKUP_DIR" && -e "$ENV_BACKUP_DIR" ]]; then
+    safe_remove_tree "$ENV_BACKUP_DIR"
+  fi
+  exit "$exit_code"
+}
+trap cleanup EXIT
+
+for path in "$APP_DIR" "$ENV_FILE" "$SYSTEMD_DIR"; do
+  [[ "$path" = /* && "$path" != "/" ]] ||
+    fail "Installationspfade müssen sichere absolute Pfade sein: ${path}"
+done
 if [[ "${EUID}" -eq 0 ]]; then
   fail "Bitte als normaler Benutzer starten: ./install.sh (nicht mit sudo)."
 fi
@@ -39,7 +108,7 @@ command -v sudo >/dev/null 2>&1 || fail "sudo wurde nicht gefunden."
 command -v apt-get >/dev/null 2>&1 || fail "Dieses Skript benötigt Raspberry Pi OS/Debian."
 command -v raspi-config >/dev/null 2>&1 || fail "raspi-config wurde nicht gefunden."
 
-echo "[1/8] Systempakete installieren"
+echo "[1/9] Systempakete installieren"
 sudo apt-get update
 sudo apt-get install -y \
   git \
@@ -50,17 +119,17 @@ sudo apt-get install -y \
   zlib1g-dev \
   libfreetype6-dev
 
-echo "[2/8] SPI aktivieren"
+echo "[2/9] SPI aktivieren"
 sudo raspi-config nonint do_spi 0
 
-echo "[3/8] Netzwerk-Zeitsynchronisierung aktivieren"
+echo "[3/9] Netzwerk-Zeitsynchronisierung aktivieren"
 if command -v timedatectl >/dev/null 2>&1; then
   sudo timedatectl set-ntp true
 else
   fail "timedatectl wurde nicht gefunden; eine korrekte Systemzeit ist erforderlich."
 fi
 
-echo "[4/8] Eingeschränkten Dienstbenutzer vorbereiten"
+echo "[4/9] Eingeschränkten Dienstbenutzer vorbereiten"
 if ! getent group "$APP_GROUP" >/dev/null; then
   sudo groupadd --system "$APP_GROUP"
 fi
@@ -85,88 +154,136 @@ for hardware_group in spi gpio; do
 done
 sudo usermod --append --groups spi,gpio "$APP_USER"
 
-echo "[5/8] Anwendung nach ${APP_DIR} kopieren"
+echo "[5/9] Neue Version separat vorbereiten"
+if [[ -e "$BACKUP_DIR" ]]; then
+  fail "Rollback-Verzeichnis ${BACKUP_DIR} existiert bereits; bitte zuerst prüfen."
+fi
+sudo install -d -m 0755 "$(dirname "$APP_DIR")" "$SYSTEMD_DIR"
+STAGING_DIR="$(sudo mktemp -d "${APP_DIR}.install.XXXXXX")"
+sudo cp -R \
+  "$SOURCE_DIR/hvv_display" \
+  "$SOURCE_DIR/systemd" \
+  "$SOURCE_DIR/docs" \
+  "$SOURCE_DIR/tests" \
+  "$STAGING_DIR/"
+sudo install -m 0644 \
+  "$SOURCE_DIR/.gitignore" \
+  "$SOURCE_DIR/README.md" \
+  "$SOURCE_DIR/config.example.json" \
+  "$SOURCE_DIR/pyproject.toml" \
+  "$SOURCE_DIR/requirements.txt" \
+  "$STAGING_DIR/"
+sudo install -m 0755 \
+  "$SOURCE_DIR/configure-credentials.sh" \
+  "$SOURCE_DIR/diagnose.sh" \
+  "$SOURCE_DIR/install.sh" \
+  "$STAGING_DIR/"
+sudo install -d -m 0750 "$STAGING_DIR/var"
+if [[ -d "$APP_DIR/var" ]]; then
+  sudo cp -a "$APP_DIR/var/." "$STAGING_DIR/var/"
+fi
+if [[ -f "$APP_DIR/config.json" ]]; then
+  sudo cp -p "$APP_DIR/config.json" "$STAGING_DIR/config.json"
+else
+  sudo install -m 0644 \
+    "$STAGING_DIR/config.example.json" "$STAGING_DIR/config.json"
+fi
+sudo chown -R root:root "$STAGING_DIR"
+sudo chown -R "$APP_USER:$APP_GROUP" "$STAGING_DIR/var"
+sudo chmod 0750 "$STAGING_DIR/var"
+sudo chmod 0644 "$STAGING_DIR/config.json"
+
+echo "[6/9] Python-Umgebung installieren und lokal prüfen"
+sudo python3 -m venv "$STAGING_DIR/.venv"
+sudo -H "$STAGING_DIR/.venv/bin/pip" install \
+  --require-hashes \
+  --requirement "$STAGING_DIR/requirements.txt"
+sudo -H "$STAGING_DIR/.venv/bin/pip" install \
+  --no-build-isolation \
+  --no-deps \
+  "$STAGING_DIR"
+sudo "$STAGING_DIR/.venv/bin/python" -m hvv_display.preview \
+  "$STAGING_DIR/var/install-preview.png"
+sudo rm -f "$STAGING_DIR/var/install-preview.png"
+
+echo "[7/9] Geofox-Zugangsdaten einrichten"
+ENV_BACKUP_DIR="$(sudo mktemp -d "${TMPDIR:-/tmp}/hvv-credentials.XXXXXX")"
+if [[ -e "$ENV_FILE" ]]; then
+  sudo cp -p "$ENV_FILE" "$ENV_BACKUP_DIR/credentials"
+else
+  sudo touch "$ENV_BACKUP_DIR/credentials.missing"
+fi
+HVV_ENV_FILE="$ENV_FILE" "$SOURCE_DIR/configure-credentials.sh"
+
+echo "[8/9] Neue Version transaktional aktivieren"
+UNIT_BACKUP_DIR="$(sudo mktemp -d "${TMPDIR:-/tmp}/hvv-units.XXXXXX")"
+backup_unit "$SERVICE_NAME.service"
+backup_unit "$LOG_CLEANUP_SERVICE"
+backup_unit "$LOG_CLEANUP_TIMER"
+sudo install -m 0644 \
+  "$STAGING_DIR/systemd/hvv-anzeiger.service" \
+  "${SYSTEMD_DIR}/${SERVICE_NAME}.service"
+sudo install -m 0644 \
+  "$STAGING_DIR/systemd/$LOG_CLEANUP_SERVICE" \
+  "$STAGING_DIR/systemd/$LOG_CLEANUP_TIMER" \
+  "$SYSTEMD_DIR/"
+
 if systemctl is-active --quiet "$SERVICE_NAME" 2>/dev/null; then
   SERVICE_WAS_ACTIVE=1
   sudo systemctl stop "$SERVICE_NAME"
 fi
-# Install the restricted unit before changing ownership so rollback also uses it.
-sudo install -m 0644 \
-  "$SOURCE_DIR/systemd/hvv-anzeiger.service" \
-  "/etc/systemd/system/${SERVICE_NAME}.service"
-sudo systemctl daemon-reload
-sudo install -d -m 0755 -o root -g root "$APP_DIR"
-sudo install -d -m 0750 -o "$APP_USER" -g "$APP_GROUP" "$APP_DIR/var"
-if [[ "$(realpath "$SOURCE_DIR")" != "$(realpath "$APP_DIR")" ]]; then
-  sudo cp -R \
-    "$SOURCE_DIR/hvv_display" \
-    "$SOURCE_DIR/systemd" \
-    "$SOURCE_DIR/docs" \
-    "$SOURCE_DIR/tests" \
-    "$APP_DIR/"
-  sudo install -m 0644 \
-    "$SOURCE_DIR/.gitignore" \
-    "$SOURCE_DIR/README.md" \
-    "$SOURCE_DIR/config.example.json" \
-    "$SOURCE_DIR/pyproject.toml" \
-    "$SOURCE_DIR/requirements.txt" \
-    "$APP_DIR/"
-  sudo install -m 0755 \
-    "$SOURCE_DIR/configure-credentials.sh" \
-    "$SOURCE_DIR/diagnose.sh" \
-    "$SOURCE_DIR/install.sh" \
-    "$APP_DIR/"
+if [[ -e "$APP_DIR" ]]; then
+  sudo mv "$APP_DIR" "$BACKUP_DIR"
 fi
-sudo chown -R root:root "$APP_DIR"
-sudo chown -R "$APP_USER:$APP_GROUP" "$APP_DIR/var"
-sudo chmod 0750 "$APP_DIR/var"
-
-echo "[6/8] Python-Umgebung installieren"
-if [[ -e "$VENV_BACKUP" ]]; then
-  fail "Temporäres Backup ${VENV_BACKUP} existiert bereits; bitte zuerst prüfen."
-fi
-if [[ -d "$APP_DIR/.venv" ]]; then
-  sudo mv "$APP_DIR/.venv" "$VENV_BACKUP"
-  VENV_BACKED_UP=1
-fi
-sudo python3 -m venv "$APP_DIR/.venv"
-sudo -H "$APP_DIR/.venv/bin/pip" install \
-  --require-hashes \
-  --requirement "$APP_DIR/requirements.txt"
-sudo -H "$APP_DIR/.venv/bin/pip" install \
+SWITCHED=1
+sudo mv "$STAGING_DIR" "$APP_DIR"
+STAGING_DIR=""
+# Console scripts contain the absolute venv path. Reinstalling the local package
+# after the move rewrites their shebangs to the final application directory.
+sudo -H "$APP_DIR/.venv/bin/python" -m pip install \
+  --force-reinstall \
   --no-build-isolation \
   --no-deps \
   "$APP_DIR"
+sudo "$APP_DIR/.venv/bin/python" -m hvv_display.preview \
+  "$APP_DIR/var/install-preview.png"
+sudo rm -f "$APP_DIR/var/install-preview.png"
 
-if [[ ! -f "$APP_DIR/config.json" ]]; then
-  sudo install -m 0644 -o root -g root \
-    "$APP_DIR/config.example.json" "$APP_DIR/config.json"
-fi
-sudo chown root:root "$APP_DIR/config.json"
-sudo chmod 0644 "$APP_DIR/config.json"
-
-echo "[7/8] Geofox-Zugangsdaten einrichten"
-HVV_ENV_FILE="$ENV_FILE" "$SOURCE_DIR/configure-credentials.sh"
-
-echo "[8/8] Autostart installieren"
-sudo install -m 0644 \
-  "$APP_DIR/systemd/hvv-anzeiger-log-cleanup.service" \
-  "$APP_DIR/systemd/hvv-anzeiger-log-cleanup.timer" \
-  /etc/systemd/system/
+echo "[9/9] Autostart aktivieren und Ergebnis prüfen"
 sudo systemctl daemon-reload
 sudo systemctl enable "$SERVICE_NAME"
 sudo systemctl enable --now "$LOG_CLEANUP_TIMER"
+sudo systemctl restart "$SERVICE_NAME" ||
+  fail "Der neue Dienst konnte nicht gestartet werden."
+sleep 2
+sudo systemctl is-active --quiet "$SERVICE_NAME" ||
+  fail "Der neue Dienst ist nach dem Start nicht aktiv."
 
-sudo systemctl restart "$SERVICE_NAME"
-echo
-echo "Installation abgeschlossen. Der Dienst wurde gestartet."
-echo "Status: systemctl status ${SERVICE_NAME}"
-
-if ((VENV_BACKED_UP == 1)); then
-  sudo rm -rf "$VENV_BACKUP"
-  VENV_BACKED_UP=0
-fi
 INSTALL_SUCCEEDED=1
+if [[ -e "$BACKUP_DIR" ]]; then
+  safe_remove_tree "$BACKUP_DIR"
+fi
+if [[ -n "$UNIT_BACKUP_DIR" && -e "$UNIT_BACKUP_DIR" ]]; then
+  safe_remove_tree "$UNIT_BACKUP_DIR"
+  UNIT_BACKUP_DIR=""
+fi
+if [[ -n "$ENV_BACKUP_DIR" && -e "$ENV_BACKUP_DIR" ]]; then
+  safe_remove_tree "$ENV_BACKUP_DIR"
+  ENV_BACKUP_DIR=""
+fi
 
 echo
+echo "Installation abgeschlossen:"
+printf "  %-24s %s\n" "Anwendung" "$APP_DIR"
+printf "  %-24s %s\n" "Geofox-Zugangsdaten" "$ENV_FILE (root:root, 0600)"
+printf "  %-24s %s\n" "Dienst" "$(systemctl is-active "$SERVICE_NAME")"
+printf "  %-24s %s\n" "Autostart" "$(systemctl is-enabled "$SERVICE_NAME")"
+printf "  %-24s %s\n" "Log-Bereinigung" "$(systemctl is-active "$LOG_CLEANUP_TIMER")"
+if [[ -e /dev/spidev0.0 ]]; then
+  printf "  %-24s %s\n" "SPI" "/dev/spidev0.0 verfügbar"
+else
+  printf "  %-24s %s\n" "SPI" "nach Neustart erneut prüfen"
+fi
+echo
+echo "Vollständige Prüfung nach dem Neustart: cd ${APP_DIR} && ./diagnose.sh"
 echo "Ein Neustart des Raspberry Pi wird empfohlen: sudo reboot"

--- a/systemd/hvv-anzeiger.service
+++ b/systemd/hvv-anzeiger.service
@@ -4,7 +4,9 @@ After=network-online.target time-sync.target
 Wants=network-online.target time-sync.target
 
 [Service]
-Type=simple
+Type=notify
+NotifyAccess=main
+WatchdogSec=90s
 User=hvv-anzeiger
 Group=hvv-anzeiger
 SupplementaryGroups=spi gpio
@@ -12,7 +14,7 @@ WorkingDirectory=/opt/hvv-anzeiger
 EnvironmentFile=/etc/hvv-anzeiger.env
 Environment=PYTHONUNBUFFERED=1
 Environment=HVV_WIFI_INTERFACE=wlan0
-ExecStart=/opt/hvv-anzeiger/.venv/bin/hvv-anzeiger --config /opt/hvv-anzeiger/config.json
+ExecStart=/opt/hvv-anzeiger/.venv/bin/python -m hvv_display --config /opt/hvv-anzeiger/config.json
 Restart=on-failure
 RestartSec=10
 UMask=0077

--- a/tests/install-smoke.sh
+++ b/tests/install-smoke.sh
@@ -101,8 +101,8 @@ printf 'smoke-application\nsmoke-password\n' | "$SOURCE_DIR/install.sh"
 
 test -x "$APP_DIR/.venv/bin/hvv-anzeiger"
 test -x "$APP_DIR/.venv/bin/hvv-preview"
-"$APP_DIR/.venv/bin/hvv-preview" "$TEST_ROOT/post-install-preview.png"
-test -s "$TEST_ROOT/post-install-preview.png"
+"$APP_DIR/.venv/bin/hvv-preview" "$ROOT/post-install-preview.png"
+test -s "$ROOT/post-install-preview.png"
 "$APP_DIR/.venv/bin/hvv-anzeiger" --help >/dev/null
 test -x "$APP_DIR/configure-credentials.sh"
 test -f "$APP_DIR/config.json"

--- a/tests/install-smoke.sh
+++ b/tests/install-smoke.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+ROOT="$(mktemp -d)"
+FAKE_BIN="$ROOT/bin"
+APP_DIR="$ROOT/opt/hvv-anzeiger"
+ENV_FILE="$ROOT/etc/hvv-anzeiger.env"
+SYSTEMD_DIR="$ROOT/systemd"
+SYSTEMCTL_STATE="$ROOT/systemctl-active"
+SOURCE_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+
+cleanup() {
+  rm -rf -- "$ROOT"
+}
+trap cleanup EXIT
+
+mkdir -p "$FAKE_BIN" "$(dirname "$ENV_FILE")" "$SYSTEMD_DIR"
+
+for command_name in \
+  apt-get raspi-config timedatectl groupadd useradd usermod getent id; do
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$FAKE_BIN/$command_name"
+  chmod 0755 "$FAKE_BIN/$command_name"
+done
+
+cat >"$FAKE_BIN/sudo" <<'EOF'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+while [[ "${1:-}" == "-H" ]]; do
+  shift
+done
+if [[ "${1:-}" == "chown" ]]; then
+  exit 0
+fi
+if [[ "${1:-}" == "install" ]]; then
+  shift
+  args=()
+  while (($#)); do
+    case "$1" in
+      -o | -g)
+        shift 2
+        ;;
+      *)
+        args+=("$1")
+        shift
+        ;;
+    esac
+  done
+  exec install "${args[@]}"
+fi
+exec "$@"
+EOF
+chmod 0755 "$FAKE_BIN/sudo"
+
+cat >"$FAKE_BIN/systemctl" <<'EOF'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+command_name="${1:-}"
+shift || true
+case "$command_name" in
+  is-active)
+    if [[ -e "$HVV_FAKE_SYSTEMCTL_STATE" ]]; then
+      [[ "${1:-}" == "--quiet" ]] || echo "active"
+      exit 0
+    fi
+    [[ "${1:-}" == "--quiet" ]] || echo "inactive"
+    exit 3
+    ;;
+  is-enabled)
+    echo "enabled"
+    ;;
+  stop)
+    rm -f "$HVV_FAKE_SYSTEMCTL_STATE"
+    ;;
+  start)
+    touch "$HVV_FAKE_SYSTEMCTL_STATE"
+    ;;
+  restart)
+    if [[ "${HVV_FAKE_FAIL_RESTART:-0}" == "1" ]]; then
+      exit 1
+    fi
+    touch "$HVV_FAKE_SYSTEMCTL_STATE"
+    ;;
+  daemon-reload | enable)
+    ;;
+  *)
+    echo "unexpected systemctl command: $command_name" >&2
+    exit 2
+    ;;
+esac
+EOF
+chmod 0755 "$FAKE_BIN/systemctl"
+
+export PATH="$FAKE_BIN:$PATH"
+export HVV_APP_DIR="$APP_DIR"
+export HVV_ENV_FILE="$ENV_FILE"
+export HVV_SYSTEMD_DIR="$SYSTEMD_DIR"
+export HVV_FAKE_SYSTEMCTL_STATE="$SYSTEMCTL_STATE"
+
+printf 'smoke-application\nsmoke-password\n' | "$SOURCE_DIR/install.sh"
+
+test -x "$APP_DIR/.venv/bin/hvv-anzeiger"
+test -x "$APP_DIR/.venv/bin/hvv-preview"
+"$APP_DIR/.venv/bin/hvv-preview" "$TEST_ROOT/post-install-preview.png"
+test -s "$TEST_ROOT/post-install-preview.png"
+"$APP_DIR/.venv/bin/hvv-anzeiger" --help >/dev/null
+test -x "$APP_DIR/configure-credentials.sh"
+test -f "$APP_DIR/config.json"
+test -f "$SYSTEMD_DIR/hvv-anzeiger.service"
+test -f "$ENV_FILE"
+test "$(stat -c '%a' "$ENV_FILE")" = "600"
+grep -q '^GEOFOX_USER="smoke-application"$' "$ENV_FILE"
+grep -q '^GEOFOX_PASSWORD="smoke-password"$' "$ENV_FILE"
+test ! -e "${APP_DIR}.previous"
+test -e "$SYSTEMCTL_STATE"
+
+touch "$APP_DIR/rollback-marker"
+printf '\n# rollback-unit-marker\n' >>"$SYSTEMD_DIR/hvv-anzeiger.service"
+printf 'GEOFOX_USER="previous-incomplete-value"\n' >"$ENV_FILE"
+chmod 0600 "$ENV_FILE"
+credential_checksum="$(sha256sum "$ENV_FILE")"
+
+if printf 'replacement-application\nreplacement-password\n' |
+  HVV_FAKE_FAIL_RESTART=1 "$SOURCE_DIR/install.sh"; then
+  echo "expected the simulated service failure to abort installation" >&2
+  exit 1
+fi
+
+test -e "$APP_DIR/rollback-marker"
+grep -q '^# rollback-unit-marker$' "$SYSTEMD_DIR/hvv-anzeiger.service"
+test "$credential_checksum" = "$(sha256sum "$ENV_FILE")"
+test ! -e "${APP_DIR}.previous"
+test -z "$(find "$(dirname "$APP_DIR")" -maxdepth 1 -name 'hvv-anzeiger.install.*' -print -quit)"
+test -e "$SYSTEMCTL_STATE"
+
+echo "Installer smoke test passed"

--- a/tests/test_clock.py
+++ b/tests/test_clock.py
@@ -1,0 +1,77 @@
+import subprocess
+import tempfile
+import unittest
+from datetime import datetime, time
+from pathlib import Path
+from unittest.mock import Mock
+
+from hvv_display.clock import in_night_shutdown, time_is_synchronized
+from hvv_display.geofox import HAMBURG_TZ
+
+
+class ClockTest(unittest.TestCase):
+    def test_sync_marker_avoids_external_command(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            marker = Path(directory) / "synchronized"
+            marker.touch()
+            run = Mock()
+            self.assertTrue(time_is_synchronized(marker=marker, run=run))
+            run.assert_not_called()
+
+    def test_timedatectl_states_and_unknown_results(self) -> None:
+        missing = Path("/definitely/missing/time-sync-marker")
+        cases = (
+            (subprocess.CompletedProcess([], 0, "yes\n", ""), True),
+            (subprocess.CompletedProcess([], 0, "no\n", ""), False),
+            (subprocess.CompletedProcess([], 0, "unexpected\n", ""), None),
+            (subprocess.CompletedProcess([], 1, "", "failed"), None),
+        )
+        for result, expected in cases:
+            with self.subTest(stdout=result.stdout, returncode=result.returncode):
+                self.assertIs(
+                    time_is_synchronized(
+                        marker=missing,
+                        run=Mock(return_value=result),
+                    ),
+                    expected,
+                )
+
+    def test_missing_timedatectl_is_unknown(self) -> None:
+        self.assertIsNone(
+            time_is_synchronized(
+                marker=Path("/definitely/missing/time-sync-marker"),
+                run=Mock(side_effect=FileNotFoundError),
+            )
+        )
+
+    def test_night_window_handles_midnight_and_daytime_ranges(self) -> None:
+        overnight_start = time(21, 0)
+        overnight_end = time(6, 30)
+        for hour, minute, expected in (
+            (20, 59, False),
+            (21, 0, True),
+            (0, 0, True),
+            (6, 29, True),
+            (6, 30, False),
+        ):
+            with self.subTest(hour=hour, minute=minute):
+                now = datetime(
+                    2026,
+                    7,
+                    27,
+                    hour,
+                    minute,
+                    tzinfo=HAMBURG_TZ,
+                )
+                self.assertEqual(
+                    in_night_shutdown(now, overnight_start, overnight_end),
+                    expected,
+                )
+
+        noon = datetime(2026, 7, 27, 12, 0, tzinfo=HAMBURG_TZ)
+        self.assertTrue(in_night_shutdown(noon, time(9), time(17)))
+        self.assertFalse(in_night_shutdown(noon, time(13), time(17)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,6 +24,9 @@ class ConfigTest(unittest.TestCase):
             ["Master:82039", "Master:82015"],
         )
         self.assertEqual([station.label for station in config.stations], ["W", "R"])
+        self.assertTrue(config.night_shutdown.enabled)
+        self.assertEqual(config.night_shutdown.start.strftime("%H:%M"), "21:00")
+        self.assertEqual(config.night_shutdown.end.strftime("%H:%M"), "06:30")
 
     def test_refresh_below_limit_is_rejected(self) -> None:
         raw = json.loads(Path("config.example.json").read_text(encoding="utf-8"))
@@ -178,6 +181,7 @@ class ConfigTest(unittest.TestCase):
             raw["display"].pop(field, None)
         raw["stations"][0].pop("label")
         raw["stations"][0].pop("city")
+        raw.pop("night_shutdown")
         with tempfile.TemporaryDirectory() as directory:
             config = load_config(self.write_config(raw, directory))
         self.assertEqual(config.api.version, 63)
@@ -185,6 +189,27 @@ class ConfigTest(unittest.TestCase):
         self.assertEqual(config.display.bus_speed_hz, 16_000_000)
         self.assertEqual(config.stations[0].label, "W")
         self.assertEqual(config.stations[0].city, "Hamburg")
+        self.assertTrue(config.night_shutdown.enabled)
+        self.assertEqual(config.night_shutdown.start.strftime("%H:%M"), "21:00")
+        self.assertEqual(config.night_shutdown.end.strftime("%H:%M"), "06:30")
+
+    def test_night_shutdown_configuration_is_validated(self) -> None:
+        original = json.loads(Path("config.example.json").read_text(encoding="utf-8"))
+        mutations = (
+            ("enabled", "yes", "true oder false"),
+            ("start", "later", "HH:MM"),
+            ("start", "6:30", "HH:MM"),
+            ("start", "06:30:00", "HH:MM"),
+            ("end", "25:00", "HH:MM"),
+            ("end", "21:00", "verschieden"),
+        )
+        for field, value, message in mutations:
+            with self.subTest(field=field, value=value):
+                raw = json.loads(json.dumps(original))
+                raw["night_shutdown"][field] = value
+                with tempfile.TemporaryDirectory() as directory:
+                    with self.assertRaisesRegex(ConfigError, message):
+                        load_config(self.write_config(raw, directory))
 
 
 if __name__ == "__main__":

--- a/tests/test_geofox_errors.py
+++ b/tests/test_geofox_errors.py
@@ -7,8 +7,10 @@ from unittest.mock import patch
 from hvv_display.geofox import (
     HAMBURG_TZ,
     MAX_RESPONSE_BYTES,
+    MAX_RETRY_AFTER_SECONDS,
     GeofoxClient,
     GeofoxError,
+    _retry_after_seconds,
 )
 from hvv_display.models import Route, Station
 
@@ -94,6 +96,50 @@ class GeofoxErrorTest(unittest.TestCase):
                 )
                 with self.assertRaisesRegex(GeofoxError, message):
                     client._post("departureList", {})
+
+    def test_rate_limit_exposes_bounded_retry_after(self) -> None:
+        error = urllib.error.HTTPError(
+            "https://example.test/departureList",
+            429,
+            "Too Many Requests",
+            {"Retry-After": "9000"},
+            io.BytesIO(b""),
+        )
+        client = GeofoxClient(
+            "https://example.test",
+            "user",
+            "secret",
+            min_request_interval=0,
+            urlopen=lambda *_args, **_kwargs: (_ for _ in ()).throw(error),
+        )
+
+        with self.assertRaises(GeofoxError) as raised:
+            client._post("departureList", {})
+        self.assertEqual(
+            raised.exception.retry_after_seconds,
+            MAX_RETRY_AFTER_SECONDS,
+        )
+
+    def test_retry_after_supports_seconds_dates_and_invalid_values(self) -> None:
+        now = datetime(2026, 7, 27, 12, 0, tzinfo=HAMBURG_TZ)
+        self.assertEqual(_retry_after_seconds("45", now=now), 45)
+        self.assertEqual(
+            _retry_after_seconds(
+                "Mon, 27 Jul 2026 10:02:00 GMT",
+                now=now,
+            ),
+            120,
+        )
+        self.assertEqual(
+            _retry_after_seconds(
+                "Mon, 27 Jul 2026 10:02:00",
+                now=now,
+            ),
+            120,
+        )
+        for value in (None, "", "invalid", "0", "-2"):
+            with self.subTest(value=value):
+                self.assertIsNone(_retry_after_seconds(value, now=now))
 
     def test_network_errors_have_safe_message(self) -> None:
         client = GeofoxClient(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import Mock, patch
 
+from PIL import Image
+
 from hvv_display.config import ConfigError, load_config
 from hvv_display.geofox import HAMBURG_TZ, GeofoxError
 from hvv_display.main import (
@@ -55,6 +57,7 @@ class MainTest(unittest.TestCase):
         self.assertEqual(refresh_delay(15, 2), 60)
         self.assertEqual(refresh_delay(15, 3), 120)
         self.assertEqual(refresh_delay(15, 20), MAX_REFRESH_BACKOFF_SECONDS)
+        self.assertEqual(refresh_delay(15, 1, retry_after_seconds=600), 600)
 
     def test_success_is_logged_as_info_at_most_hourly(self) -> None:
         with self.assertLogs("hvv_display.main", level="DEBUG") as logs:
@@ -155,6 +158,10 @@ class MainTest(unittest.TestCase):
                     "hvv_display.main.resolve_stations",
                     return_value=config.stations,
                 ),
+                patch(
+                    "hvv_display.main.clock_is_synchronized",
+                    return_value=True,
+                ),
                 patch("hvv_display.main.signal.signal"),
             ):
                 result = run()
@@ -184,12 +191,71 @@ class MainTest(unittest.TestCase):
                     "hvv_display.main.resolve_stations",
                     return_value=config.stations,
                 ),
+                patch(
+                    "hvv_display.main.clock_is_synchronized",
+                    return_value=True,
+                ),
                 patch("hvv_display.main.signal.signal"),
             ):
                 result = run()
 
             self.assertEqual(result, 1)
             self.assertTrue(output.is_file())
+
+    def test_unsynchronized_time_is_rendered_without_geofox_request(self) -> None:
+        config = load_config("config.example.json")
+        client = Mock()
+        with TemporaryDirectory() as directory:
+            output = Path(directory) / "board.png"
+            arguments = Namespace(
+                config="config.example.json",
+                cache=str(Path(directory) / "stations.json"),
+                once=True,
+                output=str(output),
+            )
+            with (
+                patch("hvv_display.main._arguments", return_value=arguments),
+                patch("hvv_display.main.GeofoxClient", return_value=client),
+                patch(
+                    "hvv_display.main.clock_is_synchronized",
+                    return_value=False,
+                ),
+                patch("hvv_display.main.signal.signal"),
+            ):
+                result = run()
+
+        self.assertEqual(result, 1)
+        client.departure_list.assert_not_called()
+        self.assertEqual(config.night_shutdown.start.strftime("%H:%M"), "21:00")
+
+    def test_night_shutdown_blanks_display_and_pauses_geofox(self) -> None:
+        client = Mock()
+        now = datetime(2026, 7, 27, 22, 0, tzinfo=HAMBURG_TZ)
+        with TemporaryDirectory() as directory:
+            output = Path(directory) / "board.png"
+            arguments = Namespace(
+                config="config.example.json",
+                cache=str(Path(directory) / "stations.json"),
+                once=True,
+                output=str(output),
+            )
+            with (
+                patch("hvv_display.main._arguments", return_value=arguments),
+                patch("hvv_display.main.GeofoxClient", return_value=client),
+                patch(
+                    "hvv_display.main.clock_is_synchronized",
+                    return_value=True,
+                ),
+                patch("hvv_display.main.datetime") as mocked_datetime,
+                patch("hvv_display.main.signal.signal"),
+            ):
+                mocked_datetime.now.return_value = now
+                result = run()
+
+            with Image.open(output) as image:
+                self.assertEqual(image.getextrema(), ((0, 0), (0, 0), (0, 0)))
+        self.assertEqual(result, 0)
+        client.departure_list.assert_not_called()
 
     def test_startup_error_returns_configuration_exit_code(self) -> None:
         arguments = Namespace(
@@ -285,6 +351,10 @@ class MainTest(unittest.TestCase):
                     return_value=config.stations,
                 ),
                 patch(
+                    "hvv_display.main.clock_is_synchronized",
+                    return_value=True,
+                ),
+                patch(
                     "hvv_display.main.signal.signal",
                     side_effect=lambda _signal, handler: handlers.append(handler),
                 ),
@@ -315,12 +385,16 @@ class MainTest(unittest.TestCase):
                     return_value=config.stations,
                 ),
                 patch(
+                    "hvv_display.main.clock_is_synchronized",
+                    return_value=True,
+                ),
+                patch(
                     "hvv_display.main.signal.signal",
                     side_effect=lambda _signal, handler: handlers.append(handler),
                 ),
                 patch(
                     "hvv_display.main.time.monotonic",
-                    side_effect=[0, 0, 0, 15, 1, 1, 1, 1],
+                    return_value=0,
                 ),
                 patch(
                     "hvv_display.main.time.sleep",
@@ -330,6 +404,50 @@ class MainTest(unittest.TestCase):
                 self.assertEqual(run(), 0)
         client.departure_list.assert_called_once()
         sleep.assert_called_once_with(1.0)
+
+    def test_continuous_mode_reuses_resolved_stations_after_deadline(self) -> None:
+        config = load_config("config.example.json")
+        handlers = []
+        calls = 0
+
+        def departures(*_args, **_kwargs):
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                handlers[0](15, None)
+            return []
+
+        client = Mock()
+        client.departure_list.side_effect = departures
+        resolved = Mock(return_value=config.stations)
+        with TemporaryDirectory() as directory:
+            arguments = Namespace(
+                config="config.example.json",
+                cache=str(Path(directory) / "stations.json"),
+                once=False,
+                output=str(Path(directory) / "board.png"),
+            )
+            with (
+                patch("hvv_display.main._arguments", return_value=arguments),
+                patch("hvv_display.main.GeofoxClient", return_value=client),
+                patch("hvv_display.main.resolve_stations", resolved),
+                patch(
+                    "hvv_display.main.clock_is_synchronized",
+                    return_value=True,
+                ),
+                patch(
+                    "hvv_display.main.signal.signal",
+                    side_effect=lambda _signal, handler: handlers.append(handler),
+                ),
+                patch(
+                    "hvv_display.main.time.monotonic",
+                    side_effect=[0, 0, 0, 15, 15, 15, 15],
+                ),
+            ):
+                self.assertEqual(run(), 0)
+
+        self.assertEqual(client.departure_list.call_count, 2)
+        resolved.assert_called_once()
 
     def test_main_exits_with_run_result(self) -> None:
         with (

--- a/tests/test_project_artifacts.py
+++ b/tests/test_project_artifacts.py
@@ -28,23 +28,28 @@ class ProjectArtifactTest(unittest.TestCase):
         credentials = ROOT / "configure-credentials.sh"
         self.assertTrue(credentials.stat().st_mode & stat.S_IXUSR)
         self.assertTrue(os.access(credentials, os.X_OK))
+        smoke_test = ROOT / "tests" / "install-smoke.sh"
+        self.assertTrue(smoke_test.stat().st_mode & stat.S_IXUSR)
+        self.assertTrue(os.access(smoke_test, os.X_OK))
         installer_text = installer.read_text(encoding="utf-8")
         self.assertIn('systemctl stop "$SERVICE_NAME"', installer_text)
         self.assertIn('enable --now "$LOG_CLEANUP_TIMER"', installer_text)
         self.assertIn('APP_USER="hvv-anzeiger"', installer_text)
         self.assertIn("--require-hashes", installer_text)
         self.assertNotIn("pip\" install --upgrade pip", installer_text)
-        self.assertIn('chown -R root:root "$APP_DIR"', installer_text)
+        self.assertIn('chown -R root:root "$STAGING_DIR"', installer_text)
         self.assertIn(
-            'chown -R "$APP_USER:$APP_GROUP" "$APP_DIR/var"', installer_text
+            'chown -R "$APP_USER:$APP_GROUP" "$STAGING_DIR/var"', installer_text
         )
-        self.assertIn("VENV_BACKED_UP", installer_text)
+        self.assertIn("BACKUP_DIR", installer_text)
+        self.assertIn("restore_units", installer_text)
         self.assertIn("INSTALL_SUCCEEDED", installer_text)
-        self.assertIn(
-            'sudo install -m 0755 \\\n'
-            '    "$SOURCE_DIR/configure-credentials.sh"',
-            installer_text,
+        self.assertIn('sudo install -m 0755 \\', installer_text)
+        self.assertIn('"$SOURCE_DIR/configure-credentials.sh"', installer_text)
+        workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(
+            encoding="utf-8"
         )
+        self.assertIn("tests/install-smoke.sh", workflow)
 
     def test_systemd_service_uses_protected_environment_file(self) -> None:
         service = (ROOT / "systemd" / "hvv-anzeiger.service").read_text(
@@ -53,6 +58,8 @@ class ProjectArtifactTest(unittest.TestCase):
         self.assertIn("EnvironmentFile=/etc/hvv-anzeiger.env", service)
         self.assertIn("Environment=HVV_WIFI_INTERFACE=wlan0", service)
         self.assertIn("Restart=on-failure", service)
+        self.assertIn("Type=notify", service)
+        self.assertIn("WatchdogSec=90s", service)
         self.assertIn("After=network-online.target time-sync.target", service)
         self.assertIn("NoNewPrivileges=true", service)
         self.assertIn("ProtectSystem=strict", service)
@@ -103,6 +110,8 @@ class ProjectArtifactTest(unittest.TestCase):
         self.assertIn("hvv-anzeiger-log-cleanup.timer", diagnostic)
         self.assertIn('credential_present "GEOFOX_USER"', diagnostic)
         self.assertIn('credential_present "GEOFOX_PASSWORD"', diagnostic)
+        self.assertIn("load_config", diagnostic)
+        self.assertIn("WatchdogUSec", diagnostic)
 
     def test_readme_documents_every_example_configuration_field(self) -> None:
         readme = (ROOT / "README.md").read_text(encoding="utf-8")
@@ -112,6 +121,7 @@ class ProjectArtifactTest(unittest.TestCase):
         fields = [
             *(f"api.{field}" for field in config["api"]),
             *(f"display.{field}" for field in config["display"]),
+            *(f"night_shutdown.{field}" for field in config["night_shutdown"]),
             *(f"stations[].{field}" for field in config["stations"][0]),
             *(
                 f"stations[].routes[].{field}"

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -91,6 +91,15 @@ class RenderTest(unittest.TestCase):
             ),
             "KEIN WLAN · STAND 12:00",
         )
+        self.assertEqual(
+            _status_text(
+                wifi_is_connected=False,
+                stale=True,
+                last_updated=now,
+                time_is_synchronized=False,
+            ),
+            "ZEIT NICHT SYNCHRON",
+        )
 
     def test_status_text_covers_wifi_stale_and_current_states(self) -> None:
         now = datetime(2026, 7, 27, 12, 0, tzinfo=HAMBURG_TZ)
@@ -124,6 +133,31 @@ class RenderTest(unittest.TestCase):
                 stale=False,
                 last_updated=now,
             )
+        )
+
+    def test_unsynchronized_time_has_visible_priority(self) -> None:
+        now = datetime(2026, 7, 27, 12, 0, tzinfo=HAMBURG_TZ)
+        image = render_board(
+            [],
+            now=now,
+            stale=True,
+            error_message="Systemzeit ist noch nicht synchronisiert",
+            wifi_is_connected=False,
+            time_is_synchronized=False,
+        )
+        self.assertEqual(image.getpixel((0, 239)), (213, 43, 47))
+        self.assertIn(
+            "ZEIT NICHT SYNCHRON",
+            board_state_key(
+                [],
+                now=now,
+                last_updated=None,
+                stale=True,
+                error_message="time",
+                wifi_is_connected=False,
+                max_rows=5,
+                time_is_synchronized=False,
+            ),
         )
 
     def test_board_state_changes_only_when_visible_content_changes(self) -> None:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,71 @@
+import unittest
+from unittest.mock import Mock, call
+
+from hvv_display.service import SystemdNotifier
+
+
+class SystemdNotifierTest(unittest.TestCase):
+    def test_ready_and_watchdog_use_notify_socket(self) -> None:
+        connection = Mock()
+        factory = Mock(return_value=connection)
+        notifier = SystemdNotifier(
+            environment={
+                "NOTIFY_SOCKET": "@test-notify",
+                "WATCHDOG_USEC": "10000000",
+                "WATCHDOG_PID": "42",
+            },
+            process_id=42,
+            socket_factory=factory,
+        )
+
+        self.assertTrue(notifier.ready())
+        self.assertTrue(notifier.ping_if_due(10))
+        self.assertFalse(notifier.ping_if_due(14))
+        self.assertTrue(notifier.ping_if_due(15))
+        self.assertEqual(
+            connection.sendto.call_args_list,
+            [
+                call(b"READY=1", "\0test-notify"),
+                call(b"WATCHDOG=1", "\0test-notify"),
+                call(b"WATCHDOG=1", "\0test-notify"),
+            ],
+        )
+        self.assertEqual(connection.close.call_count, 3)
+
+    def test_missing_or_foreign_configuration_is_a_noop(self) -> None:
+        factory = Mock()
+        missing = SystemdNotifier(environment={}, socket_factory=factory)
+        foreign = SystemdNotifier(
+            environment={
+                "NOTIFY_SOCKET": "/run/notify",
+                "WATCHDOG_USEC": "invalid",
+                "WATCHDOG_PID": "123",
+            },
+            process_id=456,
+            socket_factory=factory,
+        )
+
+        self.assertFalse(missing.ready())
+        self.assertFalse(missing.ping_if_due(1))
+        self.assertFalse(foreign.ready())
+        self.assertFalse(foreign.ping_if_due(1))
+        factory.assert_not_called()
+
+    def test_socket_error_does_not_crash_application(self) -> None:
+        connection = Mock()
+        connection.sendto.side_effect = OSError("not available")
+        notifier = SystemdNotifier(
+            environment={
+                "NOTIFY_SOCKET": "/run/notify",
+                "WATCHDOG_USEC": "2000000",
+            },
+            socket_factory=Mock(return_value=connection),
+        )
+
+        self.assertFalse(notifier.ready())
+        self.assertFalse(notifier.ping_if_due(1))
+        self.assertEqual(connection.close.call_count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Kontext

Die HVV-Anzeige soll auf einem Raspberry Pi Zero 2 W dauerhaft stabil und mit begrenztem Ressourcenverbrauch laufen. A-1 ergänzt dafür die noch offenen betrieblichen Schutzmechanismen einschließlich einer konfigurierbaren Nachtabschaltung.

## Änderungen

- Schaltet die Anzeige standardmäßig von 21:00 bis 06:30 Uhr schwarz und pausiert in diesem Zeitraum Geofox-Aufrufe; Aktivierung und Zeiten sind konfigurierbar.
- Wartet vor dem ersten Geofox-Aufruf auf eine bestätigte Systemzeit und zeigt andernfalls einen sichtbaren Hinweis.
- Berücksichtigt Retry-After bei HTTP 429 und begrenzt die Wartezeit auf eine Stunde.
- Ergänzt einen systemd-Watchdog, der einen hängenden Prozess nach 90 Sekunden neu startet.
- Macht Wiederholungsinstallationen transaktional: neue Version separat aufbauen und prüfen, kurze Umschaltung, vollständiges Rollback von Anwendung, Zugangsdaten und systemd-Units bei Fehlern.
- Ergänzt Diagnose-, Status- und Installer-Smoke-Prüfungen sowie die vollständige Dokumentation der Defaults und Betriebsgrenzen.

## Nutzer- und Produktwirkung

Die Anzeige verursacht nachts keine API-Last und keine Bildaktualisierungen, startet nach dem Nachtfenster selbstständig wieder und schützt vor falschen Abfahrtszeiten bei noch unsynchronisierter Pi-Uhr. Installation und Updates sind ausfallsicherer und verständlicher diagnostizierbar.

## Risiken und Grenzen

- Bei der dokumentierten Verdrahtung bleibt die direkt an 3,3 V angeschlossene Hintergrundbeleuchtung elektrisch an; die Software schreibt ein schwarzes Bild. Echtes Abschalten benötigt einen geeigneten Transistor oder Treiber.
- Ein echter Geofox-Vertragstest mit produktiven Zugangsdaten bleibt wie vereinbart außerhalb des Umfangs.
- Display-Hardware und Raspberry-Pi-Systemstart können erst auf dem Zielgerät abschließend geprüft werden.

## Verifikation

- 101 Unit- und Integrationstests bestanden
- 100 % Statement- und Branch-Coverage
- Ruff und ShellCheck bestanden
- Bash-Syntaxprüfung bestanden
- Python-Paket erfolgreich gebaut
- pip-audit: keine bekannten Schwachstellen
- GitHub Actions prüft zusätzlich den transaktionalen Installer-Smoke-Test unter Ubuntu und alle systemd-Units

## Review-Hinweise

Besonders relevant sind die Nachtfenster-Grenzen (Beginn inklusive, Ende exklusive), das Rollback nach simuliertem Dienstfehler und der Watchdog-Betrieb. Die README dokumentiert die Standardwerte sowie den Unterschied zwischen schwarzem Displaybild und elektrisch abgeschalteter Hintergrundbeleuchtung.

This change has been created with the support of Codex. Please review carefully to confirm that the acceptance criteria are met.