### PR TITLE
A-1: README als Anwender- und Betriebsreferenz strukturieren

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,275 +2,171 @@
 
 [![CI](https://github.com/Ben1991/hvv-anzeiger/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Ben1991/hvv-anzeiger/actions/workflows/ci.yml)
 
-Zeigt die nächsten passenden HVV-Busabfahrten auf einem 2,2-Zoll-ILI9341-SPI-Display
-mit 320 × 240 Pixeln im Querformat. Die Daten kommen alle 15 Sekunden aus der
-Geofox-GTI-API.
-
-Vorkonfiguriert sind:
-
-- Weistritzstraße: 186 nach S Othmarschen, 184 nach S Halstenbek und 384 nach
-  Elbgaustraße
-- Recknitzstraße: 21 nach U Niendorf Nord
+Der HVV-Anzeiger zeigt die nächsten passenden Busabfahrten auf einem
+2,2-Zoll-ILI9341-SPI-Display. Die Abfahrten mehrerer Haltestellen werden gemeinsam
+nach der erwarteten Abfahrtszeit sortiert und alle 15 Sekunden über die
+Geofox-GTI-API aktualisiert.
 
 ![Beispielansicht der HVV-Abfahrtsanzeige](docs/hvv-anzeiger-preview.png)
 
-Das Kürzel `W` kennzeichnet die Weistritzstraße, `R` die Recknitzstraße. Dadurch
-bleibt auch bei einer gemeinsamen, chronologisch sortierten Liste erkennbar, von
-welcher Haltestelle der Bus abfährt.
+## Funktionsumfang
 
-## Was das Programm robust macht
+- Anzeige von bis zu fünf Abfahrten auf 320 × 240 Pixeln im Querformat
+- Linie, Fahrtziel, absolute Uhrzeit und verbleibende Minuten
+- gemeinsame chronologische Sortierung über mehrere Haltestellen
+- frei konfigurierbare Linien, Ziele und Haltestellen
+- Geofox-Echtzeitprognosen einschließlich Verspätungen und Ausfällen
+- Aktualisierung im Normalbetrieb alle 15 Sekunden
+- sichtbare Hinweise bei fehlendem WLAN, veralteten Daten oder noch nicht
+  synchronisierter Systemzeit
+- Weiteranzeige des letzten erfolgreichen Datenstands bei vorübergehenden Fehlern
+- optionaler Nachtmodus mit schwarzem Bild und pausierten Geofox-Abfragen
+- automatischer Start, Neustart bei Fehlern und Überwachung durch systemd
+- wöchentliche Begrenzung der Systemprotokolle
+- Diagnosewerkzeug für die installierte Umgebung
 
-- Es nutzt Geofox-Echtzeitdaten, rechnet Verspätungen in die sichtbare Zeit ein und
-  sortiert alle Treffer nach der erwarteten Abfahrtszeit.
-- Die Zugangsdaten stehen nicht im Code oder in Git.
-- Die aktuell bestätigten Haltestellen-IDs sind vorkonfiguriert. Fehlt eine ID,
-  wird sie automatisch gesucht und lokal zwischengespeichert.
-- Ein gemeinsamer API-Aufruf fragt beide Haltestellen ab. Das respektiert das in der
-  Geofox-Dokumentation genannte Limit von durchschnittlich höchstens einer Anfrage
-  pro Sekunde.
-- Bei einem Netzwerk- oder API-Fehler bleibt der letzte erfolgreiche Stand sichtbar
-  und erhält einen roten Hinweis „DATEN VERALTET“. Nach standardmäßig fünf Minuten
-  werden alte Buszeilen ausgeblendet, damit abgelaufene Prognosen nicht dauerhaft
-  als „sofort“ erscheinen. Die Uhrzeit des letzten Datenstands bleibt sichtbar.
-- Bei getrennter WLAN-Verbindung zeigt die Statusleiste ausdrücklich „KEIN WLAN“
-  und, falls vorhanden, die Uhrzeit des letzten erfolgreichen Datenstands.
-- Solange die Systemzeit nach einem Start noch nicht synchronisiert ist, wird
-  „ZEIT NICHT SYNCHRON“ angezeigt und Geofox nicht abgefragt. Dadurch können
-  keine scheinbar plausiblen Abfahrten auf Basis einer falschen Pi-Uhr erscheinen.
-- Der optionale Nachtmodus kann die Anzeige täglich von 21:00 bis 06:30 Uhr
-  vollständig schwarz schalten und währenddessen die Geofox-Abrufe pausieren.
-  Er ist standardmäßig deaktiviert; Aktivierung und Zeitraum sind konfigurierbar.
-- Bei wiederholten Fehlern verdoppelt sich der Abstand zwischen den Versuchen bis
-  maximal fünf Minuten. Der Anzeigezustand wird trotzdem alle 15 Sekunden geprüft.
-  Eine von Geofox bei HTTP 429 verlangte längere Wartezeit wird bis maximal eine
-  Stunde respektiert. Nach einem erfolgreichen Abruf gelten wieder 15 Sekunden.
-- Schriftarten werden im Arbeitsspeicher wiederverwendet. Ein neues Bild wird nur
-  gerendert und über SPI übertragen, wenn sich der sichtbare Inhalt geändert hat.
-  Das spart CPU-Zeit und SPI-Übertragungen, ohne die Geofox-Abrufe zu reduzieren.
-- Sowohl HTTP-Fehler als auch Geofox-Fehler im JSON-Feld `returnCode` werden geprüft.
-- Geofox-Antworten sind auf 1 MiB begrenzt, damit eine fehlerhafte Server- oder
-  Proxy-Antwort nicht unkontrolliert Arbeitsspeicher belegt.
-- Erfolgreiche Routineabrufe stehen im Debug-Log. Auf Info-Ebene erscheint höchstens
-  einmal pro Stunde ein Lebenszeichen; Fehler bleiben sofort sichtbar. Das reduziert
-  unnötige Schreibzugriffe auf die SD-Karte.
-- Ein systemd-Timer bereinigt das Journal wöchentlich. Archivierte Einträge, die
-  älter als sieben Tage sind, werden entfernt; zusätzlich wird der archivierte
-  Journalbestand auf 100 MiB begrenzt.
-- Der systemd-Dienst startet erst nach Netzwerk- und Zeitsynchronisierungs-Targets.
-  Das ist wichtig, weil ein Raspberry Pi üblicherweise keine Echtzeituhr besitzt.
-- Ein systemd-Watchdog erwartet spätestens alle 90 Sekunden ein Lebenszeichen.
-  Dadurch wird nicht nur ein abgestürzter, sondern auch ein hängender Prozess
-  automatisch neu gestartet.
-- Der systemd-Dienst darf das Betriebssystem, Benutzerverzeichnisse und den
-  Anwendungscode nicht verändern. Schreibzugriff besteht nur auf den lokalen
-  Haltestellen-Cache unter `/opt/hvv-anzeiger/var`.
-- Der Dienst läuft unter dem nicht interaktiven Systembenutzer `hvv-anzeiger`.
-  Programmcode und Konfiguration gehören `root`; nur das Cache-Verzeichnis gehört
-  dem Dienstbenutzer.
-- Geofox-Anfragen sind ausschließlich über HTTPS an `gti.geofox.de` erlaubt.
-  Externe Fehlermeldungen werden vor der Ausgabe auf eine einzelne sichere
-  Protokollzeile begrenzt.
-- Laufzeit- und Testabhängigkeiten sind vollständig mit Versionen und
-  SHA-256-Prüfsummen gesperrt. Der Dependency Audit in CI prüft jede Änderung
-  zusätzlich gegen bekannte Sicherheitsmeldungen.
+### Vorkonfigurierte Verbindungen
 
-## Sicherheitsmodell
+| Kürzel | Haltestelle | Linie | Ziel |
+|---|---|---:|---|
+| W | Weistritzstraße | 186 | S Othmarschen |
+| W | Weistritzstraße | 184 | S Halstenbek |
+| W | Weistritzstraße | 384 | Elbgaustraße |
+| R | Recknitzstraße | 21 | U Niendorf Nord |
 
-Der Raspberry Pi stellt durch diese Anwendung keinen eingehenden Netzwerkdienst
-bereit. Die einzige Netzwerkkommunikation sind ausgehende HTTPS-Anfragen an
-Geofox. Die Zugangsdaten liegen als `root:root` mit Dateirechten `0600` unter
-`/etc/hvv-anzeiger.env` und werden weder in Git noch als Kommandozeilenparameter
-gespeichert.
-
-Die Installation trennt drei Bereiche:
-
-| Bereich | Eigentümer | Rechte des Dienstes |
-|---|---|---|
-| Programm und virtuelle Umgebung unter `/opt/hvv-anzeiger` | `root:root` | lesen und ausführen |
-| Konfiguration `/opt/hvv-anzeiger/config.json` | `root:root` | nur lesen |
-| Laufzeitdaten `/opt/hvv-anzeiger/var` | `hvv-anzeiger:hvv-anzeiger` | lesen und schreiben |
-
-Der Benutzer `hvv-anzeiger` besitzt keine Login-Shell und erhält nur über die
-Gruppen `spi` und `gpio` Zugriff auf die Display-Hardware. Die systemd-Sandbox
-verhindert zusätzlich Änderungen an Betriebssystem, Kernel-Einstellungen,
-Benutzerverzeichnissen und Anwendungscode.
-
-Sicherheitsupdates werden in zwei Stufen geprüft:
-
-- `requirements.txt` und `requirements-dev.txt` enthalten festgelegte
-  Versionen und die erlaubten Paketprüfsummen. Eine manipulierte Paketdatei wird
-  bei der Installation abgelehnt.
-- GitHub Actions führt `pip-audit` gegen die Laufzeit-Lockdatei aus. Bekannte
-  Abhängigkeitsschwachstellen lassen den Workflow fehlschlagen.
-
-### Einmalige GitHub-Einstellungen für den Repository-Owner
-
-Einige Schutzfunktionen liegen nicht im Repository und können deshalb nicht durch
-einen Commit aktiviert werden. Der Owner sollte einmalig in den
-Repository-Einstellungen prüfen:
-
-- **Dependabot Alerts** und **Dependabot Security Updates** aktivieren. Die Datei
-  `.github/dependabot.yml` übernimmt danach die wöchentlichen, in CI geprüften
-  Versionsupdates.
-- `main` mit einer Branch-Regel oder einem Ruleset schützen, den Workflow **CI**
-  als erforderlichen Check setzen und Force-Push sowie Branch-Löschung
-  deaktivieren.
-- **Secret Scanning** aktivieren, falls es für den verwendeten GitHub-Tarif
-  verfügbar ist.
-- Optional **Code Scanning/CodeQL** aktivieren, falls es für das private
-  Repository verfügbar ist. Ruff Security und `pip-audit` laufen unabhängig
-  davon bereits bei jedem Push und Pull Request.
-
-Nur ein Repository-Owner oder Benutzer mit Admin-Rechten kann diese Einstellungen
-ändern. Der aktuelle Zustand lässt sich unter **Settings → Security** und
-**Settings → Rules** kontrollieren.
-
-Voraussetzung ist **Python 3.10 oder neuer**. Empfohlen wird Raspberry Pi OS
-Bookworm 64 Bit mit Python 3.11. Python 3.9 wird nicht mehr unterstützt, weil die
-bereinigte Pillow-Version 12.3.0 mindestens Python 3.10 benötigt.
+Das Kürzel zeigt bei einer gemeinsam sortierten Liste, von welcher Haltestelle
+die jeweilige Abfahrt stammt.
 
 ## Welche Abfahrtszeit wird angezeigt?
 
-Die Anzeige verwendet nicht einfach die unveränderte Fahrplanzeit, sondern die
-aktuelle Geofox-Echtzeitprognose:
+Die Anzeige verwendet die aktuelle Geofox-Prognose:
 
 ```text
-angezeigte Abfahrt = Planabfahrt + von Geofox gemeldete Verspätung
+erwartete Abfahrtszeit = Planabfahrt + gemeldete Verspätung
 ```
 
-Geofox liefert die Verspätung in Sekunden. Sowohl die große Restzeit wie
-`7 min` als auch die kleine absolute Uhrzeit wie `12:34` werden aus dieser
-korrigierten Abfahrtszeit berechnet. Die Prognose wird regulär alle 15 Sekunden
-neu abgerufen.
+Die große Restzeit und die kleine absolute Uhrzeit basieren beide auf dieser
+erwarteten Abfahrtszeit. Liefert Geofox keine Verspätung, wird die Planzeit
+verwendet. Gemeldete Ausfälle erscheinen als `AUS`.
 
-Wichtig: Bei einer zukünftigen Abfahrt ist dies die aktuell bestmögliche
-Prognose, nicht eine bereits gemessene tatsächliche Abfahrt. Liefert Geofox keine
-Verspätung, wird die planmäßige Abfahrtszeit verwendet. Gemeldete Ausfälle werden
-statt einer Restzeit mit `AUS` gekennzeichnet.
+Eine zukünftige Abfahrt ist immer eine Prognose. Sie ist nicht mit einer bereits
+gemessenen tatsächlichen Abfahrt gleichzusetzen.
 
-## Benötigte Hardware
+## Unterstütztes Setup
 
-- Raspberry Pi Zero 2 W mit Raspberry Pi OS Lite (64 Bit empfohlen)
-- 2,2-Zoll-TFT mit ILI9341-Controller, 240 × 320 Pixel
+### Hardware
+
+- Raspberry Pi Zero 2 W
+- microSD-Karte
+- zuverlässiges 5-V-Netzteil mit mindestens 2 A
+- 2,2-Zoll-TFT mit ILI9341-Controller und 240 × 320 Pixeln
 - passende Jumper-Kabel
 
-### Beispielverdrahtung
+### Software
 
-Die Bezeichnungen auf Display-Modulen unterscheiden sich. `SCK` kann auch `CLK`,
+- Raspberry Pi OS Lite Bookworm
+- 64-Bit-Ausgabe empfohlen
+- Python 3.10 oder neuer
+- WLAN mit Internetzugang
+- gültige Geofox-GTI-Zugangsdaten
+
+Andere Raspberry-Pi-Modelle oder ILI9341-Module können funktionieren, sind aber
+nicht das dokumentierte Zielsetup. Pinbelegung, Spannungsversorgung,
+Hintergrundbeleuchtung und Farbreihenfolge müssen zum konkreten Display-Modul
+passen.
+
+## Verdrahtung
+
+Die Bezeichnungen unterscheiden sich je nach Modul. `SCK` kann auch `CLK`,
 `MOSI` auch `SDI` oder `DIN` und `CS` auch `CE` heißen.
 
 | Display | Raspberry Pi | Physischer Pin |
 |---|---|---:|
 | VCC | 3,3 V | 1 |
 | GND | GND | 6 |
-| SCK / CLK | GPIO 11 (SPI0 SCLK) | 23 |
-| MOSI / SDI | GPIO 10 (SPI0 MOSI) | 19 |
-| CS / CE | GPIO 8 (SPI0 CE0) | 24 |
+| SCK / CLK | GPIO 11, SPI0 SCLK | 23 |
+| MOSI / SDI | GPIO 10, SPI0 MOSI | 19 |
+| CS / CE | GPIO 8, SPI0 CE0 | 24 |
 | DC / RS | GPIO 24 | 18 |
 | RST / RESET | GPIO 25 | 22 |
 | LED | 3,3 V | 17 |
 
-> Das Display nur mit 3,3-V-Logik betreiben. Vor dem Anschluss das Datenblatt des
-> konkreten Moduls prüfen. Die Hintergrundbeleuchtung nicht direkt über einen
-> GPIO-Pin versorgen, wenn das Modul dafür keinen geeigneten Vorwiderstand oder
-> Treiber besitzt.
+Vor dem Verdrahten das Datenblatt des konkreten Moduls prüfen. Das Display mit
+3,3-V-Logik betreiben. Die Hintergrundbeleuchtung darf nur dann direkt an 3,3 V
+angeschlossen werden, wenn das Modul den benötigten Vorwiderstand oder Treiber
+enthält. Sie nicht ungeprüft direkt aus einem GPIO-Pin versorgen.
 
-Die Nachtabschaltung schreibt ein vollständig schwarzes Bild und pausiert die
-Netzwerkabrufe. Bei der oben gezeigten Verdrahtung bleibt `LED` jedoch an 3,3 V
-und damit elektrisch eingeschaltet. Für eine wirklich ausgeschaltete
-Hintergrundbeleuchtung ist ein zum konkreten Modul passender Transistor- oder
-Treiberbaustein erforderlich; die LED sollte nicht ungeprüft direkt an einen
-GPIO-Pin angeschlossen werden. Ein schwarzes Bild allein spart bei einem
-beleuchteten TFT praktisch keinen Displaystrom. Der optionale Nachtmodus reduziert
-lediglich etwas CPU-, SPI- und WLAN-Arbeit.
+## Strom- und Ressourcenverbrauch
 
-## Erwarteter Ressourcenverbrauch auf dem Pi Zero 2 W
+### Durchschnittlicher Stromverbrauch
 
-Die folgenden Werte sind realistische Orientierungswerte, aber noch keine Messung
-auf dem konkreten Raspberry Pi und Display. Betriebssystem, Python-/Pillow-Version,
-WLAN-Qualität und Größe der Geofox-Antwort beeinflussen die tatsächlichen Werte.
+Für das dokumentierte Setup ist im Dauerbetrieb folgender Planungswert realistisch:
 
-| Ressource | Erwartungswert | Auswirkung |
-|---|---:|---|
-| Arbeitsspeicher | ungefähr 40–70 MiB im Dauerbetrieb | deutlich unter den 512 MiB des Pi Zero 2 W; Raspberry Pi OS Lite und die Anzeige sollten ausreichend Reserve haben |
-| CPU | meist niedriger einstelliger Prozentbereich im zeitlichen Mittel, mit kurzen Spitzen beim API-Abruf und Rendern | die vier Kerne werden nicht dauerhaft belastet; andere kleine Dienste können parallel laufen |
-| Bildspeicher | 230.400 Byte pro 320 × 240-RGB-Bild, zeitweise wenige Bildpuffer | weniger als einige MiB; für den Pi unkritisch |
-| SPI | 230.400 Byte pro vollständig übertragenem Bild | bei unveränderter Anzeige meist nur etwa einmal pro Minute statt viermal; bei jeder sichtbaren Änderung sofort |
-| Netzwerk | bis zu 240 Geofox-Abrufe pro Stunde; bei aktiviertem Nachtmodus während des Nachtfensters keine | typischerweise wenige MiB pro aktiver Stunde; die Antwortgröße bestimmt den exakten Wert |
-| Installation | grob 50–120 MiB für Anwendung, virtuelle Python-Umgebung und Bibliotheken | die Paket-Caches des Betriebssystems können zusätzlich Speicherplatz belegen |
+| Messpunkt | Erwarteter Verbrauch |
+|---|---:|
+| Raspberry Pi Zero 2 W, aktiv | ungefähr 1,8 W |
+| vergleichbares 2,2-Zoll-ILI9341-Modul | ungefähr 0,4 W |
+| komplettes Setup am USB-Eingang | ungefähr 2,2–2,6 W |
+| komplettes Setup an der Steckdose einschließlich Netzteilverlusten | ungefähr 2,5–3,0 W |
+| sinnvoller Planungswert | **ungefähr 2,7 W im Durchschnitt** |
 
-Der größte dauerhafte Stromverbrauch entsteht voraussichtlich durch Raspberry Pi,
-WLAN und Display-Hintergrundbeleuchtung, nicht durch das Python-Programm. Für diese
-Anwendung ist normalerweise keine aktive Kühlung nötig. In einem engen,
-schlecht belüfteten Gehäuse sollte die Temperatur nach einigen Stunden dennoch
-kontrolliert werden.
+Bei 2,7 W und durchgehendem Betrieb entspricht das ungefähr:
 
-Die Anwendung vermeidet unnötige Arbeit:
+- 0,065 kWh pro Tag
+- 2,0 kWh pro Monat
+- 24 kWh pro Jahr
 
-- Geofox wird weiterhin alle 15 Sekunden abgefragt, damit Echtzeitänderungen schnell
-  sichtbar werden. Nur bei aktiviertem Nachtmodus entfallen zwischen 21:00 und
-  06:30 Uhr die Abrufe vollständig; 240 Abrufe pro Stunde sind der Höchstwert
-  während der aktiven Anzeigezeit.
-- Solange Uhrzeit, Abfahrten und Statushinweis gleich bleiben, entfallen Rendering
-  und SPI-Transfer vollständig.
-- Geladene Schriftarten werden wiederverwendet.
-- Zwischen Aktualisierungen wacht der Prozess höchstens einmal pro Sekunde auf.
-  Dadurch reagiert der Dienst weiterhin zeitnah auf ein Stoppsignal, ohne viermal
-  pro Sekunde unnötig aktiv zu werden.
+Die Schätzung basiert auf dem von Raspberry Pi dokumentierten typischen aktiven
+Strom von 350 mA für den Zero 2 W und 0,42 W für ein vergleichbares
+2,2-Zoll-ILI9341-Modul. Das konkrete Display-Board, WLAN-Empfang, Netzteil und
+CPU-Auslastung verändern den tatsächlichen Wert. Quellen:
+[Raspberry Pi power supply documentation](https://www.raspberrypi.com/documentation/computers/raspberry-pi.html#power-supply)
+und
+[LCDWiki MSP2202 manual](https://www.lcdwiki.com/res/MSP2202/2.2inch_SPI_Module_MSP2202_User_Manual_EN.pdf).
 
-### Verbrauch auf dem eigenen Pi messen
+Ein USB-Leistungsmessgerät zwischen Netzteil und Raspberry Pi liefert den
+verlässlichen Wert für das eigene Gerät. Ein Steckdosenmessgerät erfasst
+zusätzlich die Verluste des Netzteils.
 
-Nach einigen Minuten Laufzeit liefern diese Befehle aussagekräftigere Werte für
-das konkrete Gerät:
+### Wirkung des Nachtmodus
 
-```bash
-pid="$(systemctl show --property MainPID --value hvv-anzeiger)"
-ps -p "$pid" -o pid,%cpu,rss,etime,cmd
-systemctl show hvv-anzeiger -p MemoryCurrent -p CPUUsageNSec
-du -sh /opt/hvv-anzeiger
-awk '{printf "%.1f °C\n", $1 / 1000}' /sys/class/thermal/thermal_zone0/temp
-```
+Der Nachtmodus zeigt ein schwarzes Bild und pausiert die Geofox-Abfragen. Bei der
+oben dokumentierten Verdrahtung bleibt `LED` jedoch dauerhaft an 3,3 V. Ein
+schwarzes TFT-Bild spart deshalb praktisch keinen Displaystrom. Die geringere
+CPU-, SPI- und WLAN-Aktivität reduziert den Gesamtverbrauch nur wenig.
 
-`RSS` wird von `ps` in KiB ausgegeben. Für einen belastbaren CPU-Mittelwert den
-`ps`-Befehl mehrmals über einige Minuten ausführen. Das Netzwerkvolumen lässt sich
-vor und nach einer Stunde anhand der RX-/TX-Zähler von `wlan0` vergleichen:
+Für eine relevante Einsparung muss die Hintergrundbeleuchtung elektrisch
+abgeschaltet werden. Dafür ist ein zum Modul passender Transistor oder
+Treiberbaustein erforderlich. Diese Hardwaresteuerung ist nicht Bestandteil des
+Projekts.
 
-```bash
-grep wlan0 /proc/net/dev
-```
+### Weitere Ressourcen
 
-### Log-Aufbewahrung
+| Ressource | Erwartungswert |
+|---|---:|
+| Arbeitsspeicher | ungefähr 40–70 MiB |
+| CPU | im Mittel meist niedriger einstelliger Prozentbereich |
+| Netzwerk | maximal 240 Geofox-Abfragen pro aktiver Stunde |
+| Anwendungsinstallation | ungefähr 50–120 MiB |
+| Displaybild | 230.400 Byte pro RGB-Bild |
 
-`hvv-anzeiger-log-cleanup.timer` läuft standardmäßig einmal pro Woche. Durch
-`Persistent=true` wird eine während eines ausgeschalteten Raspberry Pi verpasste
-Ausführung beim nächsten Start nachgeholt. Vor der Bereinigung wird das aktive
-Journal rotiert. Danach gelten zwei Grenzen:
-
-- archivierte Journal-Einträge älter als sieben Tage werden gelöscht,
-- archivierte Journale belegen zusammen höchstens 100 MiB.
-
-Journald verwaltet die Meldungen aller systemd-Dienste gemeinsam. Die Bereinigung
-betrifft deshalb das gesamte Systemjournal, nicht nur `hvv-anzeiger`. Die jeweils
-letzte Woche bleibt weiterhin beispielsweise mit `journalctl -u hvv-anzeiger`
-abrufbar. Status und aktuellen Speicherverbrauch prüfen:
-
-```bash
-systemctl status hvv-anzeiger-log-cleanup.timer
-journalctl --disk-usage
-```
-
-Für einen sofortigen manuellen Bereinigungslauf:
-
-```bash
-sudo systemctl start hvv-anzeiger-log-cleanup.service
-```
+Die Werte sind Richtwerte und keine Messung des konkreten Geräts. Für dieses
+Setup ist normalerweise keine aktive Kühlung erforderlich. In einem engen,
+schlecht belüfteten Gehäuse sollte die Temperatur nach einigen Stunden geprüft
+werden.
 
 ## Installation
 
-### Schnellinstallation
+### Voraussetzungen
 
-Raspberry Pi OS verwendet Linux. Deshalb ist die Installationsdatei ein
-Bash-Skript (`install.sh`) und keine Windows-`.bat`-Datei.
+Vor der Installation werden benötigt:
+
+1. Raspberry Pi OS Lite mit funktionierendem WLAN
+2. Zugang per Terminal oder SSH
+3. Geofox Application-ID und Geofox-Passwort
+4. korrekt angeschlossenes Display
+
+### Automatische Installation
 
 ```bash
 git clone https://github.com/Ben1991/hvv-anzeiger.git
@@ -279,240 +175,112 @@ chmod +x install.sh
 ./install.sh
 ```
 
-Das Skript:
+`install.sh` richtet das vollständige System ein:
 
-- installiert die benötigten System- und Python-Pakete,
-- aktiviert SPI,
-- installiert die Anwendung unter `/opt/hvv-anzeiger`,
-- fragt bei der ersten Installation die Geofox Application-ID und das Passwort
-  interaktiv ab; das Passwort bleibt bei der Eingabe unsichtbar,
-- übernimmt eine vorhandene `config.json` und vollständige Zugangsdaten bei
-  späteren Updates unverändert,
-- baut Programmcode und Python-Umgebung zuerst vollständig in einem separaten
-  Verzeichnis auf und rendert dort ein Testbild,
-- stoppt den laufenden Dienst erst für die kurze Umschaltung,
-- stellt bei einem Installations- oder Startfehler die komplette vorherige
-  Anwendung einschließlich Python-Umgebung und systemd-Units wieder her,
-- aktiviert die Netzwerk-Zeitsynchronisierung,
-- legt den nicht interaktiven Systembenutzer `hvv-anzeiger` an,
-- schützt Programmcode und Konfiguration als `root:root` und gibt dem Dienst nur
-  Schreibrecht auf `var`,
-- installiert ausschließlich die in `requirements.txt` festgelegten Pakete mit
-  geprüften SHA-256-Hashes,
-- aktiviert die wöchentliche Journal-Bereinigung,
-- aktiviert den Autostart und den 90-Sekunden-Watchdog,
-- zeigt zum Abschluss einen kompakten Statusblock für Dienst, Autostart,
-  Log-Bereinigung und SPI.
+- benötigte Betriebssystem- und Python-Pakete
+- SPI und Netzwerk-Zeitsynchronisierung
+- Anwendung unter `/opt/hvv-anzeiger`
+- geschützter Dienstbenutzer `hvv-anzeiger`
+- Geofox-Zugangsdaten unter `/etc/hvv-anzeiger.env`
+- Autostart, Prozessüberwachung und Log-Bereinigung
 
-Die Zugangsdaten werden weder als Kommandozeilenparameter noch im Repository
-gespeichert. Der Installer schreibt sie atomar mit den Dateirechten `0600` nach
-`/etc/hvv-anzeiger.env`. Bricht die Eingabe ab oder bleibt ein Wert leer, startet
-der Dienst nicht mit einer unvollständigen Konfiguration. Nach der erstmaligen
-SPI-Aktivierung sollte der Raspberry Pi neu gestartet werden.
+Bei der ersten Installation fragt das Skript die Geofox Application-ID und das
+Passwort ab. Das Passwort bleibt bei der Eingabe unsichtbar. Eine vollständige
+vorhandene Zugangsdaten-Datei und eine vorhandene `config.json` werden bei
+späteren Installationen beibehalten.
 
-Der laufende Dienst wird erst beendet, nachdem Abhängigkeiten, Paketinstallation
-und lokales Rendern der neuen Version erfolgreich waren. Schlägt der anschließende
-Start fehl, wird die vorherige Version automatisch zurückgeschaltet und erneut
-gestartet.
+Die neue Version wird vor der Umschaltung vollständig vorbereitet und geprüft.
+Falls ihr Dienst anschließend nicht startet, werden Anwendung, Zugangsdaten und
+systemd-Konfiguration auf den vorherigen Stand zurückgesetzt.
 
-### Manuelle Installation
-
-### 1. Raspberry Pi vorbereiten
-
-```bash
-sudo apt update
-sudo apt install -y git python3-venv python3-dev fonts-dejavu-core \
-  libjpeg-dev zlib1g-dev libfreetype6-dev
-sudo raspi-config
-sudo timedatectl set-ntp true
-```
-
-In `raspi-config` **Interface Options → SPI → Yes** wählen und anschließend neu
-starten:
+Nach der ersten Installation den Raspberry Pi neu starten:
 
 ```bash
 sudo reboot
 ```
 
-Nach dem Neustart sollte `/dev/spidev0.0` existieren:
+### Installation prüfen
 
-```bash
-ls -l /dev/spidev0.0
-timedatectl status
-```
-
-Bei `System clock synchronized` muss `yes` stehen, bevor die echten Abfahrtszeiten
-geprüft werden.
-
-### 2. Anwendung installieren
-
-Die manuelle Installation verwendet denselben eingeschränkten Dienstbenutzer und
-dieselbe geprüfte Lockdatei wie `install.sh`:
-
-```bash
-git clone https://github.com/Ben1991/hvv-anzeiger.git
-cd hvv-anzeiger
-
-getent group hvv-anzeiger >/dev/null ||
-  sudo groupadd --system hvv-anzeiger
-id -u hvv-anzeiger >/dev/null 2>&1 ||
-  sudo useradd --system --gid hvv-anzeiger \
-    --home-dir /opt/hvv-anzeiger --no-create-home \
-    --shell /usr/sbin/nologin hvv-anzeiger
-sudo usermod --append --groups spi,gpio hvv-anzeiger
-
-sudo install -d -m 0755 -o root -g root /opt/hvv-anzeiger
-sudo cp -R hvv_display systemd /opt/hvv-anzeiger/
-sudo install -m 0644 README.md config.example.json pyproject.toml \
-  requirements.txt /opt/hvv-anzeiger/
-sudo install -m 0755 configure-credentials.sh diagnose.sh \
-  /opt/hvv-anzeiger/
-sudo install -d -m 0750 -o hvv-anzeiger -g hvv-anzeiger \
-  /opt/hvv-anzeiger/var
-
-sudo python3 -m venv /opt/hvv-anzeiger/.venv
-sudo -H /opt/hvv-anzeiger/.venv/bin/pip install \
-  --require-hashes --requirement /opt/hvv-anzeiger/requirements.txt
-sudo -H /opt/hvv-anzeiger/.venv/bin/pip install \
-  --no-build-isolation --no-deps /opt/hvv-anzeiger
-sudo install -m 0644 -o root -g root config.example.json \
-  /opt/hvv-anzeiger/config.json
-```
-
-`config.json` kann unverändert als Startpunkt dienen. Falls das Bild auf dem Kopf
-steht, `display.rotate` von `0` auf `2` ändern. Bei vertauschten Farben
-`display.bgr` auf `true` setzen.
-
-### 3. Geofox-Zugangsdaten hinterlegen
-
-Die von Geofox erhaltene Application-ID und das Passwort werden einmalig
-interaktiv abgefragt und in einer geschützten Systemdatei gespeichert. Das
-Passwort ist während der Eingabe nicht sichtbar:
-
-```bash
-./configure-credentials.sh
-```
-
-Eine Wiederholungsinstallation übernimmt vollständige Zugangsdaten automatisch.
-Um sie später bewusst zu ersetzen:
-
-```bash
-cd /opt/hvv-anzeiger
-./configure-credentials.sh --force
-sudo systemctl restart hvv-anzeiger
-```
-
-Das Hilfsskript gibt das Passwort nie aus, speichert Sonderzeichen korrekt und
-setzt Eigentümer und Rechte der Datei auf `root:root` und `0600`.
-
-### 4. Einmaliger Funktionstest
-
-```bash
-cd /opt/hvv-anzeiger
-set -a
-. /etc/hvv-anzeiger.env
-set +a
-.venv/bin/python -m hvv_display --config config.json --once
-```
-
-Die Beispielkonfiguration enthält die geprüften IDs `Master:82039` für
-Weistritzstraße und `Master:82015` für Recknitzstraße. Falls eine ID entfernt oder
-eine neue Haltestelle ergänzt wird, sucht das Programm sie über Geofox. Die
-ermittelte ID landet in `var/stations.json`. Bei mehreren gleichnamigen Treffern
-nennt das Programm die Kandidaten; dann die gewünschte ID als `"id": "Master:..."`
-beim entsprechenden Eintrag in `config.json` ergänzen.
-
-Für einen Test ohne angeschlossenes Display kann eine PNG-Datei geschrieben werden:
-
-```bash
-.venv/bin/python -m hvv_display.preview preview.png
-```
-
-Oder mit echten API-Daten:
-
-```bash
-.venv/bin/python -m hvv_display --config config.json --once --output preview.png
-```
-
-### 5. Automatischen Start einrichten
-
-Der Dienst verwendet immer den eigens angelegten Benutzer `hvv-anzeiger`. `User=`
-und `Group=` sollten nicht auf den normalen Login-Benutzer geändert werden.
-
-```bash
-sudo cp systemd/hvv-anzeiger.service \
-  systemd/hvv-anzeiger-log-cleanup.service \
-  systemd/hvv-anzeiger-log-cleanup.timer \
-  /etc/systemd/system/
-sudo systemctl daemon-reload
-sudo systemctl enable --now hvv-anzeiger
-sudo systemctl enable --now hvv-anzeiger-log-cleanup.timer
-```
-
-Status und Protokoll anzeigen:
-
-```bash
-systemctl status hvv-anzeiger
-journalctl -u hvv-anzeiger -f
-systemctl list-timers hvv-anzeiger-log-cleanup.timer
-```
-
-Eine vollständige Softwarediagnose auf dem Raspberry Pi ausführen:
+Nach dem Neustart:
 
 ```bash
 cd /opt/hvv-anzeiger
 ./diagnose.sh
 ```
 
-Sie prüft Linux, SPI, Zeitsynchronisierung, Installation, Zugangsdaten,
-WLAN-Verbindung, Autostart, Dienststatus, Journal-Bereinigung und das lokale
-Rendern eines Displaybilds. Zugangsdaten werden dabei nicht ausgegeben.
+Die Diagnose prüft:
 
-Nach Änderungen an `config.json`:
+- Linux und SPI-Gerät
+- WLAN und Systemzeit
+- Anwendung und Konfiguration
+- Geofox-Zugangsdaten
+- Dienst, Autostart und Watchdog
+- Dienstbenutzer und Dateirechte
+- Log-Bereinigung
+- lokales Rendern eines Displaybilds
 
-```bash
-sudo systemctl restart hvv-anzeiger
-```
+Zugangsdaten werden dabei nicht ausgegeben.
 
 ## Konfiguration
 
-`config.example.json` enthält alle empfohlenen Werte. Optionale Felder dürfen
-weggelassen werden; dann gelten die folgenden Defaults aus dem Programmcode.
+Die aktive Konfiguration liegt unter:
 
-### API-Defaults
+```text
+/opt/hvv-anzeiger/config.json
+```
+
+Bearbeiten und anschließend den Dienst neu starten:
+
+```bash
+sudo nano /opt/hvv-anzeiger/config.json
+sudo systemctl restart hvv-anzeiger
+```
+
+`config.example.json` enthält eine vollständige Beispielkonfiguration. Wird ein
+optionales Feld weggelassen, gilt der nachfolgend dokumentierte Code-Default.
+
+### API
 
 | Feld | Default | Bedeutung und Grenze |
 |---|---:|---|
-| `api.base_url` | kein Default, Pflichtfeld | ausschließlich HTTPS auf `gti.geofox.de`; im Beispiel `https://gti.geofox.de/gti/public` |
-| `api.version` | `63` | verwendete Geofox-GTI-Version |
-| `api.refresh_seconds` | `15` | regulärer Abstand der Echtzeitabrufe; mindestens 15 Sekunden |
-| `api.request_timeout_seconds` | `8` | Zeitlimit pro HTTP-Anfrage; muss größer als 0 sein |
-| `api.max_departures` | `5` | maximal sichtbare Zeilen; erlaubt sind 1 bis 5 |
-| `api.max_time_offset_minutes` | `90` | Geofox-Suchzeitraum ab der aktuellen Uhrzeit; muss größer als 0 sein |
-| `api.max_stale_age_minutes` | `5` | so lange dürfen alte Buszeilen bei einem Abruffehler sichtbar bleiben; danach bleibt nur der Fehlerstatus mit letztem Datenstand |
+| `api.base_url` | Pflichtfeld | muss `https://gti.geofox.de/gti/public` verwenden |
+| `api.version` | `63` | Geofox-GTI-API-Version |
+| `api.refresh_seconds` | `15` | Aktualisierungsabstand; mindestens 15 Sekunden |
+| `api.request_timeout_seconds` | `8` | HTTP-Zeitlimit in Sekunden; größer als 0 |
+| `api.max_departures` | `5` | sichtbare Abfahrten; 1 bis 5 |
+| `api.max_time_offset_minutes` | `90` | betrachteter Zeitraum ab jetzt; größer als 0 |
+| `api.max_stale_age_minutes` | `5` | maximale Anzeigezeit alter Abfahrtszeilen bei einem Fehler |
 
-### Display-Defaults
+Die Anwendung akzeptiert für `api.base_url` ausschließlich HTTPS und den
+offiziellen Host `gti.geofox.de`.
+
+### Display
 
 | Feld | Default | Bedeutung und Grenze |
 |---|---:|---|
 | `display.spi_port` | `0` | SPI-Port |
-| `display.spi_device` | `0` | SPI-Gerät beziehungsweise Chip-Select; entspricht üblicherweise `/dev/spidev0.0` |
+| `display.spi_device` | `0` | SPI-Gerät beziehungsweise Chip-Select |
 | `display.gpio_dc` | `24` | GPIO-Nummer für Data/Command |
 | `display.gpio_reset` | `25` | GPIO-Nummer für Reset |
 | `display.rotate` | `0` | Drehung; erlaubt sind 0, 1, 2 oder 3 |
-| `display.bus_speed_hz` | `16000000` | SPI-Takt in Hertz; muss größer als 0 sein |
-| `display.bgr` | `false` | auf `true` setzen, falls Rot und Blau vertauscht sind |
+| `display.bus_speed_hz` | `16000000` | SPI-Takt; größer als 0 |
+| `display.bgr` | `false` | auf `true` setzen, wenn Rot und Blau vertauscht sind |
 
-### Nachtabschaltungs-Defaults
+Für ein um 180 Grad gedrehtes Display üblicherweise `display.rotate` auf `2`
+setzen.
+
+### Nachtmodus
 
 | Feld | Default | Bedeutung und Grenze |
 |---|---:|---|
-| `night_shutdown.enabled` | `false` | aktiviert mit `true` das schwarze Displaybild und die Geofox-Pause im konfigurierten Zeitraum |
-| `night_shutdown.start` | `"21:00"` | Beginn im lokalen Hamburger Zeitformat `HH:MM` |
-| `night_shutdown.end` | `"06:30"` | Ende im lokalen Hamburger Zeitformat `HH:MM`; muss sich vom Beginn unterscheiden |
+| `night_shutdown.enabled` | `false` | aktiviert den Nachtmodus |
+| `night_shutdown.start` | `"21:00"` | Beginn als lokale Hamburger Zeit im Format `HH:MM` |
+| `night_shutdown.end` | `"06:30"` | Ende im Format `HH:MM`; muss vom Beginn abweichen |
 
-Zeiträume über Mitternacht und innerhalb eines Tages werden unterstützt. Beginn
-ist eingeschlossen, das Ende ausgeschlossen. Zum Aktivieren des Nachtmodus:
+Der Beginn ist eingeschlossen, das Ende ausgeschlossen. Zeiträume über
+Mitternacht und Zeiträume innerhalb desselben Tages werden unterstützt.
+
+Beispiel für die Aktivierung von 21:00 bis 06:30 Uhr:
 
 ```json
 "night_shutdown": {
@@ -522,21 +290,53 @@ ist eingeschlossen, das Ende ausgeschlossen. Zum Aktivieren des Nachtmodus:
 }
 ```
 
-### Haltestellen-Defaults
+Im Nachtfenster wird einmal ein schwarzes Bild geschrieben. Geofox-Abfragen
+pausieren bis zum Ende des Fensters.
+
+### Haltestellen und Verbindungen
 
 | Feld | Default | Bedeutung und Grenze |
 |---|---|---|
-| `stations` | kein Default, Pflichtfeld | mindestens eine Haltestelle |
-| `stations[].name` | kein Default, Pflichtfeld | Haltestellenname |
+| `stations` | Pflichtfeld | mindestens eine Haltestelle |
+| `stations[].name` | Pflichtfeld | Geofox-Haltestellenname |
 | `stations[].city` | `"Hamburg"` | Stadt für die Haltestellensuche |
-| `stations[].id` | keine | optionale Geofox-ID; ohne ID wird sie gesucht und unter `var/stations.json` gespeichert |
-| `stations[].label` | erster Buchstabe des Namens | eindeutiges Kürzel mit 1 bis 3 Zeichen; wird in Großbuchstaben angezeigt |
-| `stations[].routes` | kein Default, Pflichtfeld | mindestens eine erlaubte Kombination aus Linie und Ziel |
-| `stations[].routes[].line` | kein Default, Pflichtfeld | Linienbezeichnung, beispielsweise `"21"` |
-| `stations[].routes[].destination` | kein Default, Pflichtfeld | erwartetes Fahrtziel |
+| `stations[].id` | kein Default | optionale eindeutige Geofox-ID |
+| `stations[].label` | erster Buchstabe des Namens | eindeutiges sichtbares Kürzel mit 1 bis 3 Zeichen |
+| `stations[].routes` | Pflichtfeld | mindestens eine erlaubte Linie-Ziel-Kombination |
+| `stations[].routes[].line` | Pflichtfeld | Linienbezeichnung, zum Beispiel `"21"` |
+| `stations[].routes[].destination` | Pflichtfeld | erwartetes Fahrtziel |
 
-Die WLAN-Schnittstelle ist standardmäßig `wlan0`. Falls das Betriebssystem einen
-anderen Namen verwendet, den systemd-Dienst überschreiben:
+Beispiel:
+
+```json
+{
+  "name": "Recknitzstraße",
+  "city": "Hamburg",
+  "id": "Master:82015",
+  "label": "R",
+  "routes": [
+    {
+      "line": "21",
+      "destination": "U Niendorf Nord"
+    }
+  ]
+}
+```
+
+Fehlt `stations[].id`, sucht die Anwendung die Haltestelle bei Geofox und speichert
+die gefundene ID unter `/opt/hvv-anzeiger/var/stations.json`. Bei mehreren
+gleichnamigen Treffern muss die gewünschte ID ausdrücklich in `config.json`
+eingetragen werden.
+
+Linien und Ziele werden tolerant gegenüber Groß-/Kleinschreibung, Umlauten und
+Schreibweisen wie `Straße` und `Strasse` verglichen. Ein zusätzliches
+Verkehrsmittel-Präfix im Geofox-Ziel, beispielsweise `S Elbgaustraße`, wird
+ebenfalls berücksichtigt.
+
+### WLAN-Schnittstelle
+
+Der Dienst überwacht standardmäßig `wlan0`. Falls die WLAN-Schnittstelle anders
+heißt:
 
 ```bash
 sudo systemctl edit hvv-anzeiger
@@ -549,133 +349,133 @@ Folgenden Inhalt eintragen:
 Environment=HVV_WIFI_INTERFACE=DEINE_WLAN_SCHNITTSTELLE
 ```
 
-Danach neu laden und starten:
+Danach:
 
 ```bash
 sudo systemctl daemon-reload
 sudo systemctl restart hvv-anzeiger
 ```
 
-Linien und Ziele werden tolerant gegenüber Groß-/Kleinschreibung, Umlauten und
-Schreibweisen wie `Straße`/`Strasse` verglichen. Dadurch passt zum Beispiel das
-konfigurierte Ziel „Elbgaustraße“ auch auf „S Elbgaustraße“ aus der API.
+## Verhalten bei Störungen
 
-## Tests
+| Situation | Verhalten auf dem Display | Automatische Reaktion |
+|---|---|---|
+| WLAN getrennt | `KEIN WLAN`; letzter Datenstand bleibt sichtbar | neue Abfrage nach Wiederverbindung |
+| Geofox vorübergehend nicht erreichbar | `DATEN VERALTET`; letzter Datenstand bleibt sichtbar | wachsender Abstand bis maximal fünf Minuten |
+| alte Daten älter als `api.max_stale_age_minutes` | alte Buszeilen verschwinden; Fehlerstatus bleibt | weitere Abrufversuche |
+| Geofox-Anfragelimit erreicht | Fehlerstatus | `Retry-After` wird bis maximal eine Stunde respektiert |
+| Systemzeit noch nicht synchron | `ZEIT NICHT SYNCHRON` | keine Geofox-Abfrage bis zur Synchronisierung |
+| Prozess abgestürzt oder länger als 90 Sekunden blockiert | Anzeige bleibt kurz auf letztem Bild | systemd startet den Dienst neu |
+| Nachtmodus aktiv | schwarzes Bild | keine Geofox-Abfrage bis zum Ende des Nachtfensters |
 
-Auf einem Entwicklungsrechner:
+## Betrieb und Wartung
+
+### Dienst steuern
 
 ```bash
-python3.11 -m venv .venv
-.venv/bin/pip install --require-hashes --requirement requirements-dev.txt
-.venv/bin/pip install --no-build-isolation --no-deps --editable .
-.venv/bin/ruff check .
-.venv/bin/coverage run -m unittest discover -s tests -v
-.venv/bin/coverage report
-.venv/bin/pip-audit --requirement requirements.txt --disable-pip
-.venv/bin/python -m hvv_display.preview preview.png
-bash -n install.sh configure-credentials.sh diagnose.sh
-shellcheck install.sh configure-credentials.sh diagnose.sh tests/install-smoke.sh
+systemctl status hvv-anzeiger
+sudo systemctl restart hvv-anzeiger
+sudo systemctl stop hvv-anzeiger
+sudo systemctl start hvv-anzeiger
 ```
 
-`tests/install-smoke.sh` läuft in GitHub Actions auf Ubuntu. Es führt eine
-vollständige Erstinstallation mit isolierten Systempfaden und Kommando-Doubles
-für Raspberry-Pi-Systembefehle aus. Anschließend erzwingt es einen fehlgeschlagenen
-Dienststart und prüft, dass Anwendung, Zugangsdaten und systemd-Units vollständig
-auf den vorherigen Stand zurückgesetzt werden.
+### Protokoll ansehen
 
-Die automatisierten Tests prüfen unter anderem:
+```bash
+journalctl -u hvv-anzeiger -n 100 --no-pager
+journalctl -u hvv-anzeiger -f
+```
 
-- Konfigurationsgrenzen und die vorkonfigurierten Haltestellen,
-- HMAC-Signatur, HTTP-/Geofox-Fehler und mehrdeutige Haltestellensuchen,
-- Größenbegrenzung von Geofox-Antworten und Ablauf veralteter Abfahrten,
-- Linienfilter, Echtzeitverspätungen, Sortierung und Zeitumstellungen,
-- Haltestellen-Cache und atomisches Speichern gefundener IDs,
-- eine dokumentationsnahe, anonymisierte Geofox-Beispielantwort vom API-Eingang
-  bis zum gerenderten Displaybild,
-- Herkunftskennzeichnung pro Haltestelle und begrenztes Fehler-Backoff,
-- Geofox-`Retry-After`, Nachtfenster über Mitternacht und das Pausieren der API,
-- Zeitstatus vor dem ersten Geofox-Abruf und Watchdog-Lebenszeichen,
-- stündlich begrenztes Erfolgs-Logging, gehärteten systemd-Dienst und
-  wiederherstellbare Python-Installation,
-- HTTPS-/Host-Prüfung, einzeilige externe Fehlertexte, den dedizierten
-  Dienstbenutzer und root-eigenen Anwendungscode,
-- Prüfsummen der installierten Pakete und bekannte
-  Abhängigkeitsschwachstellen,
-- wöchentliche Journal-Bereinigung mit Alters- und Größenlimit,
-- verbundene, getrennte, unbekannte und alternativ benannte WLAN-Schnittstellen,
-- normale, leere und veraltete Anzeigezustände,
-- Screenshot, Installationsskript, Pi-Diagnose und systemd-Konfiguration.
-- einmalige, verdeckte Zugangsdatenabfrage, sichere Dateirechte, Wiederverwendung
-  vorhandener Zugangsdaten und bewusste Rotation mit `--force`.
-- vollständige isolierte Erstinstallation und transaktionales Rollback bei einem
-  simulierten Dienstfehler.
+Das Systemjournal wird wöchentlich rotiert. Archivierte Einträge über sieben Tage
+werden entfernt und archivierte Journale auf insgesamt 100 MiB begrenzt. Diese
+Bereinigung betrifft das gesamte systemd-Journal des Raspberry Pi, nicht nur den
+HVV-Anzeiger.
 
-GitHub Actions führt diese Prüfungen nach jedem Push und für jeden Pull Request mit
-Python 3.10, 3.11 und 3.13 aus. Zusätzlich werden Ruff einschließlich seiner
-Security-Regeln, eine Mindest-Testabdeckung von 100 Prozent, `pip-audit`, beide
-Shell-Skripte mit Bash und ShellCheck, ein Vorschaubild und das installierbare
-Python-Paket sowie der transaktionale Installer-Smoke-Test geprüft.
+Status der Bereinigung:
 
-Alle direkten und transitiven Laufzeitabhängigkeiten sind mit Prüfsummen in
-`requirements.txt` festgeschrieben. `requirements-dev.txt` ergänzt die ebenfalls
-gesperrten Test- und Build-Werkzeuge. Dependabot sucht wöchentlich nach
-kontrollierten Aktualisierungen für Python-Pakete und GitHub Actions.
+```bash
+systemctl status hvv-anzeiger-log-cleanup.timer
+journalctl --disk-usage
+```
 
-Der echte Displayzugriff und der authentifizierte Geofox-Produktivzugang können
-weiterhin erst mit Hardware beziehungsweise gültigen Zugangsdaten geprüft werden.
+### Zugangsdaten ändern
 
-## Abnahme auf dem Raspberry Pi
+```bash
+cd /opt/hvv-anzeiger
+./configure-credentials.sh --force
+sudo systemctl restart hvv-anzeiger
+```
 
-Nach Installation, Zugangsdaten und Neustart:
+Die Zugangsdaten liegen unter `/etc/hvv-anzeiger.env`, gehören `root:root` und
+haben die Dateirechte `0600`.
 
-1. `./diagnose.sh` muss ohne Fehler enden.
-2. Das Display muss fünf Zeilen vollständig und scharf darstellen.
-3. Rot und Blau müssen korrekt sein; andernfalls `display.bgr` ändern.
-4. `W` und `R` müssen die richtige Ausgangshaltestelle kennzeichnen.
-5. WLAN kurz trennen: Der letzte Stand muss mit „KEIN WLAN“ sichtbar bleiben.
-6. WLAN wieder verbinden: Die Anzeige muss selbstständig zu 15 Sekunden
-   Aktualisierung zurückkehren.
-7. Den Raspberry Pi neu starten und mit `systemctl status hvv-anzeiger` prüfen,
-   dass die Anzeige ohne manuelles Eingreifen wieder läuft.
-8. Für einen Nachtfunktionstest `night_shutdown.enabled` auf `true`,
-   `night_shutdown.start` kurz auf wenige Minuten vor die aktuelle Zeit und
-   `night_shutdown.end` auf wenige Minuten danach setzen: Das Bild muss schwarz
-   werden und nach Ende des Fensters selbstständig zurückkehren. Anschließend die
-   gewünschten Werte wiederherstellen.
-9. `systemctl show hvv-anzeiger -p Type -p WatchdogUSec` muss `Type=notify` und
-   einen Watchdog-Wert von 90 Sekunden anzeigen.
+### Anwendung aktualisieren
 
-## Technischer Hintergrund
+Im ursprünglich geklonten Repository:
 
-Die Anwendung verwendet die Geofox-Methode
-`POST /gti/public/departureList` mit API-Version 63 und `useRealtime: true`.
-Die Signatur ist Base64-codiertes HMAC-SHA1 über den exakten UTF-8-JSON-Body.
-Jede Anfrage bekommt eine eigene `X-TraceId`, die bei Fehlern im Log steht.
-Bei HTTP 429 wird ein gültiger `Retry-After`-Wert respektiert und aus
-Sicherheitsgründen auf höchstens eine Stunde begrenzt.
+```bash
+git pull --ff-only
+./install.sh
+```
 
-Das Display wird über `luma.lcd` angesteuert. Die Oberfläche selbst wird mit Pillow
-als 320 × 240 Pixel großes RGB-Bild erzeugt und anschließend vollständig auf das
-ILI9341 übertragen. Bereits geladene Schriftarten werden zwischengespeichert.
-Ein Bild wird nur neu erzeugt und übertragen, wenn sich sein sichtbarer Inhalt
-gegenüber dem vorherigen Bild geändert hat.
+Vorhandene Konfiguration und vollständige Zugangsdaten bleiben erhalten. Neue
+Defaults verändern deshalb keine bereits vorhandene `config.json`.
 
-Vor dem ersten API-Abruf prüft die Anwendung den Synchronisationsmarker von
-`systemd-timesyncd` und ersatzweise `timedatectl`. Nach der ersten bestätigten
-Synchronisierung gilt die Uhr für die Laufzeit des Prozesses als verwendbar.
-Während des Nachtfensters wird genau einmal ein schwarzes Bild übertragen; weitere
-Renderings und Geofox-Anfragen entfallen bis zum Ende des Zeitraums.
+### Vorschau ohne Display erzeugen
 
-Der Dienst läuft als nicht interaktiver Benutzer `hvv-anzeiger` mit
-systemd-Schutzmechanismen wie `NoNewPrivileges` und einem schreibgeschützten
-Betriebssystem- und Anwendungsbereich. Programm, virtuelle Umgebung und
-Konfiguration gehören `root`; `/opt/hvv-anzeiger/var` ist die einzige explizite
-Schreibausnahme für den Haltestellen-Cache. Ein bewusstes RAM-Limit ist nicht
-gesetzt: Die dokumentierten Messbefehle sollten zuerst auf dem konkreten Pi
-ausgeführt werden, damit ein zu knapp angesetztes Limit nicht unnötig zu
-Neustarts führt.
+```bash
+cd /opt/hvv-anzeiger
+.venv/bin/python -m hvv_display.preview preview.png
+```
 
-Der Dienst verwendet `Type=notify` und meldet Bereitschaft sowie regelmäßige
-Watchdog-Lebenszeichen direkt über den von systemd bereitgestellten Unix-Socket.
-Bleibt ein Lebenszeichen länger als 90 Sekunden aus, beendet und startet systemd
-den Prozess neu.
+Mit Geofox-Daten, aber weiterhin als PNG:
+
+```bash
+cd /opt/hvv-anzeiger
+set -a
+. /etc/hvv-anzeiger.env
+set +a
+.venv/bin/python -m hvv_display \
+  --config config.json --once --output preview.png
+```
+
+## Sicherheit und Datenschutz
+
+- Die Anwendung stellt keinen eingehenden Netzwerkdienst bereit.
+- Ausgehende API-Kommunikation ist auf HTTPS zu `gti.geofox.de` beschränkt.
+- Geofox-Zugangsdaten stehen weder im Repository noch in Prozessargumenten.
+- Der Dienst läuft als nicht interaktiver Benutzer `hvv-anzeiger`.
+- Programm, virtuelle Python-Umgebung und Konfiguration sind für den Dienst
+  schreibgeschützt.
+- Nur `/opt/hvv-anzeiger/var` ist für Laufzeitdaten beschreibbar.
+- Geofox-Antworten sind auf 1 MiB begrenzt.
+- Python-Abhängigkeiten sind mit Versionen und SHA-256-Prüfsummen festgelegt.
+- GitHub Actions prüft Abhängigkeiten auf bekannte Schwachstellen.
+
+## Grenzen
+
+- Ein Geofox-Zugang ist erforderlich; es gibt keinen öffentlichen
+  Zugangsdaten-freien Fallback.
+- Ohne synchronisierte Systemzeit werden keine Abfahrten abgerufen.
+- Die maximale Zahl sichtbarer Abfahrten ist wegen der Displaygröße auf fünf
+  begrenzt.
+- Das Zielsetup ist ein ILI9341 mit 320 × 240 Pixeln im Querformat.
+- Der Nachtmodus schaltet die Hintergrundbeleuchtung nicht elektrisch aus.
+- Die erwartete Abfahrtszeit bleibt eine Prognose und kann sich bis zur Abfahrt
+  ändern.
+- Verbindliche Strom-, RAM- und CPU-Werte erfordern eine Messung am konkreten
+  Raspberry Pi, Display und Netzteil.
+- Display-Hardware und authentifizierte Geofox-Produktivantworten können in
+  GitHub Actions nicht geprüft werden.
+
+## Qualitätsprüfung
+
+Bei jedem Push und Pull Request prüft GitHub Actions:
+
+- Python 3.10, 3.11 und 3.13
+- Unit- und Integrationstests mit 100 Prozent Coverage
+- Code- und Security-Linting
+- bekannte Schwachstellen in Laufzeitabhängigkeiten
+- Shell-Skripte und systemd-Units
+- vollständige Installation und Rollback in einer isolierten Ubuntu-Umgebung
+- Paket-Build und Display-Vorschau


### PR DESCRIPTION
## Kontext

Die README war historisch auf 681 Zeilen angewachsen und vermischte Funktionsbeschreibung, interne Umsetzung, manuelle Parallelinstallation, Repository-Administration und Betrieb. Dadurch waren die tatsächlich unterstützten Funktionen, Defaults und Grenzen schwer zu erfassen.

## Änderungen

- Strukturiert die README vollständig als Anwender- und Betriebsreferenz.
- Beschreibt Funktionsumfang, vorkonfigurierte Verbindungen und Echtzeitsemantik zuerst.
- Dokumentiert Zielhardware, Verdrahtung, Voraussetzungen und einen eindeutigen Installationsweg.
- Erfasst sämtliche Konfigurationsfelder und Defaults aus `config.example.json`.
- Ergänzt Störungsverhalten, Betrieb, Updates, Zugangsdaten, Sicherheit und bekannte Grenzen.
- Entfernt historische Umsetzungserzählungen, interne Algorithmusdetails, manuelle Parallelinstallation und Repository-Admin-Anleitungen.
- Ergänzt einen transparent hergeleiteten Planungswert von ungefähr 2,7 W durchschnittlicher Leistungsaufnahme an der Steckdose beziehungsweise rund 24 kWh pro Jahr im 24/7-Betrieb.

## Nutzer- und Produktwirkung

Neue Anwender können das unterstützte Setup ohne konkurrierende Installationspfade aufbauen. Betreiber finden Konfiguration, Fehlerbilder und Wartungsbefehle an definierten Stellen. Stromangaben sind als Schätzung mit Annahmen und Quellen gekennzeichnet und nicht als Messwert des konkreten Geräts dargestellt.

## Risiken und Grenzen

- Der Stromwert bleibt eine Planungsgröße; Display-Board, WLAN, Netzteil und Auslastung beeinflussen die tatsächliche Messung.
- Ein schwarzes TFT-Bild spart bei dauerhaft versorgter Hintergrundbeleuchtung praktisch keinen Displaystrom.
- Es wurden ausschließlich Dokumentationsinhalte geändert; Laufzeitverhalten und Konfiguration bleiben unverändert.

## Verifikation

- Alle Felder aus `config.example.json` sind dokumentiert.
- README-Screenshot und Abmessungen wurden durch die Artefakttests geprüft.
- 101 Tests bestanden, 100 % Statement- und Branch-Coverage.
- Ruff, Bash-Syntaxprüfung, ShellCheck und `git diff --check` bestanden.
- Externe Verbrauchsquellen wurden gegen Raspberry-Pi-Dokumentation und das Handbuch eines vergleichbaren ILI9341-Moduls geprüft.

## Review-Hinweise

Bitte insbesondere Stromannahmen, den einzigen empfohlenen Installationsweg und die Vollständigkeit der Konfigurationstabellen prüfen.

This change has been created with the support of Codex. Please review carefully to confirm that the acceptance criteria are met.