### PR TITLE
A-1: Automatischen Start nach Reboot absichern

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,43 @@ Die Diagnose prüft:
 
 Zugangsdaten werden dabei nicht ausgegeben.
 
+### Automatischer Start nach Reboot oder Stromausfall
+
+Der Installer aktiviert `hvv-anzeiger` dauerhaft als systemd-Dienst. Nach einem
+normalen Neustart oder nachdem die Stromversorgung wiederhergestellt wurde,
+startet die Anzeige ohne Anmeldung und ohne manuellen Befehl.
+
+Beim Hochfahren gilt:
+
+1. systemd startet den Anzeigedienst automatisch.
+2. Solange die Systemzeit noch nicht synchronisiert ist, zeigt das Display
+   `ZEIT NICHT SYNCHRON` und es werden keine Geofox-Daten abgefragt.
+3. Fehlt WLAN, zeigt das Display `KEIN WLAN`.
+4. Sobald Systemzeit und Netzwerk verfügbar sind, lädt die Anwendung selbstständig
+   aktuelle Geofox-Daten und setzt den normalen 15-Sekunden-Zyklus fort.
+5. Endet oder blockiert der Prozess später unerwartet, startet systemd ihn erneut.
+
+Autostart und aktuellen Zustand prüfen:
+
+```bash
+systemctl is-enabled hvv-anzeiger
+systemctl status hvv-anzeiger --no-pager
+```
+
+Der erste Befehl muss `enabled` ausgeben. Falls nicht:
+
+```bash
+sudo systemctl enable --now hvv-anzeiger
+```
+
+`install.sh` wird bewusst nicht bei jedem Boot ausgeführt. Es dient nur zur
+Installation und für Updates; automatisch gestartet wird die bereits installierte
+Anzeige.
+
+Ein harter Stromausfall kann unabhängig von dieser Anwendung eine beschriebene
+microSD-Karte beschädigen. Für häufige oder kritische Stromunterbrechungen sind
+ein zuverlässiges Netzteil und gegebenenfalls eine kleine USV sinnvoll.
+
 ## Konfiguration
 
 Die aktive Konfiguration liegt unter:

--- a/diagnose.sh
+++ b/diagnose.sh
@@ -115,6 +115,15 @@ else
   fail "Der Dienst läuft nicht."
 fi
 
+RESTART_POLICY="$(
+  systemctl show "$SERVICE_NAME" --property=Restart --value 2>/dev/null
+)"
+if [[ "$RESTART_POLICY" == "always" ]]; then
+  pass "Der Dienst wird nach einem unerwarteten Prozessende automatisch neu gestartet."
+else
+  fail "Die automatische Prozesswiederherstellung ist nicht korrekt aktiviert."
+fi
+
 SERVICE_TYPE="$(
   systemctl show "$SERVICE_NAME" --property=Type --value 2>/dev/null
 )"

--- a/systemd/hvv-anzeiger.service
+++ b/systemd/hvv-anzeiger.service
@@ -15,7 +15,7 @@ EnvironmentFile=/etc/hvv-anzeiger.env
 Environment=PYTHONUNBUFFERED=1
 Environment=HVV_WIFI_INTERFACE=wlan0
 ExecStart=/opt/hvv-anzeiger/.venv/bin/python -m hvv_display --config /opt/hvv-anzeiger/config.json
-Restart=on-failure
+Restart=always
 RestartSec=10
 UMask=0077
 NoNewPrivileges=true

--- a/tests/test_project_artifacts.py
+++ b/tests/test_project_artifacts.py
@@ -35,6 +35,7 @@ class ProjectArtifactTest(unittest.TestCase):
         self.assertIn('systemctl stop "$SERVICE_NAME"', installer_text)
         self.assertIn('enable --now "$LOG_CLEANUP_TIMER"', installer_text)
         self.assertIn('APP_USER="hvv-anzeiger"', installer_text)
+        self.assertIn('systemctl enable "$SERVICE_NAME"', installer_text)
         self.assertIn("--require-hashes", installer_text)
         self.assertNotIn("pip\" install --upgrade pip", installer_text)
         self.assertIn('chown -R root:root "$STAGING_DIR"', installer_text)
@@ -57,10 +58,11 @@ class ProjectArtifactTest(unittest.TestCase):
         )
         self.assertIn("EnvironmentFile=/etc/hvv-anzeiger.env", service)
         self.assertIn("Environment=HVV_WIFI_INTERFACE=wlan0", service)
-        self.assertIn("Restart=on-failure", service)
+        self.assertIn("Restart=always", service)
         self.assertIn("Type=notify", service)
         self.assertIn("WatchdogSec=90s", service)
         self.assertIn("After=network-online.target time-sync.target", service)
+        self.assertIn("WantedBy=multi-user.target", service)
         self.assertIn("NoNewPrivileges=true", service)
         self.assertIn("ProtectSystem=strict", service)
         self.assertIn("ProtectHome=true", service)
@@ -111,6 +113,7 @@ class ProjectArtifactTest(unittest.TestCase):
         self.assertIn('credential_present "GEOFOX_USER"', diagnostic)
         self.assertIn('credential_present "GEOFOX_PASSWORD"', diagnostic)
         self.assertIn("load_config", diagnostic)
+        self.assertIn("--property=Restart", diagnostic)
         self.assertIn("WatchdogUSec", diagnostic)
 
     def test_readme_documents_every_example_configuration_field(self) -> None:


### PR DESCRIPTION
## Kontext

Die HVV-Anzeige soll nach einem regulären Neustart oder nach Wiederkehr der Stromversorgung ohne Anmeldung und ohne manuellen Befehl wieder starten und aktuelle Daten laden.

Der Dienst war bereits dauerhaft für `multi-user.target` aktiviert. Diese Änderung macht die Wiederherstellung expliziter, prüfbar und vollständig dokumentiert.

## Änderungen

- Setzt die systemd-Restart-Policy auf `Restart=always`, damit auch ein unerwartetes sauberes Prozessende automatisch wiederhergestellt wird.
- Behält den 90-Sekunden-Watchdog für blockierte Prozesse und den bestehenden Autostart über `WantedBy=multi-user.target` bei.
- Prüft die Restart-Policy zusätzlich in `diagnose.sh`.
- Ergänzt Artefakttests für Installer-Aktivierung, Boot-Target und Restart-Policy.
- Dokumentiert den vollständigen Boot-Ablauf nach Reboot oder Stromausfall, einschließlich Zeit-/WLAN-Wartezustand, manueller Prüfung und Reparatur des Autostarts.
- Stellt klar, dass `install.sh` nicht bei jedem Boot erneut ausgeführt wird.
- Dokumentiert das verbleibende SD-Karten-Risiko bei hartem Stromverlust.

## Nutzer- und Produktwirkung

Nach dem Hochfahren startet die Anzeige automatisch. Sobald Systemzeit und WLAN verfügbar sind, lädt sie selbstständig aktuelle Geofox-Daten und setzt den 15-Sekunden-Zyklus fort. Ein unerwartet beendeter oder blockierter Prozess wird ebenfalls neu gestartet.

## Risiken und Grenzen

- Ein harter Stromausfall kann die microSD-Karte unabhängig von der Anwendung beschädigen; für häufige Ausfälle ist eine kleine USV sinnvoll.
- Eine ungültige Konfiguration oder fehlende Zugangsdaten können weiterhin verhindern, dass die Anwendung erfolgreich bereit wird. Die Diagnose zeigt diese Ursachen an.
- Ein bewusstes `systemctl stop hvv-anzeiger` bleibt wirksam und löst keinen Neustart aus.

## Verifikation

- 101 Tests bestanden.
- 100 % Statement- und Branch-Coverage.
- Ruff, Bash-Syntaxprüfung und ShellCheck bestanden.
- systemd-Unit und Installer-Autostart werden durch Artefakttests und GitHub Actions geprüft.
- Der isolierte Installer-Smoke-Test prüft weiterhin Aktivierung, Dienststart und Rollback.

## Review-Hinweise

Bitte insbesondere `Restart=always`, die Abgrenzung zwischen Autostart der Anwendung und Nicht-Ausführung des Installers beim Boot sowie das Verhalten bei fehlendem WLAN oder noch unsynchronisierter Zeit prüfen.

This change has been created with the support of Codex. Please review carefully to confirm that the acceptance criteria are met.