### PR TITLE
A-1: Geofox-Zugang und Ko-fi-Link dokumentieren

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,69 @@ verwendet. Gemeldete Ausfälle erscheinen als `AUS`.
 Eine zukünftige Abfahrt ist immer eine Prognose. Sie ist nicht mit einer bereits
 gemessenen tatsächlichen Abfahrt gleichzusetzen.
 
+## Datenquelle und Geofox-Zugang
+
+### Was ist Geofox GTI?
+
+Das
+[Geofox Thin Interface (GTI)](https://gti.geofox.de/)
+ist die REST-ähnliche Web-Service-Schnittstelle der Geofox-Fahrplanauskunft. Sie
+stellt unter anderem Haltestellen, Linien, Abfahrten, Fahrtverläufe sowie Plan- und
+Echtzeitinformationen bereit. Dieses Projekt verwendet die Abfahrtsliste mit
+aktivierten Echtzeitdaten, um Verspätungen und gemeldete Ausfälle zu
+berücksichtigen.
+
+Geofox beziehungsweise die Schnittstelle wird von der HBT Hamburger Berater Team
+GmbH betrieben. Der Schnittstellenzugang und die Datenbereitstellung für
+HVV-Fahrplandaten werden auf der
+[offiziellen HVV-Seite für individuelle Entwicklerprojekte](https://www.hvv.de/de/fahrplaene/abruf-fahrplaninfos/datenabruf)
+beschrieben. Dieses Repository ist ein unabhängiges Projekt und kein offizielles
+Produkt von HVV, HOCHBAHN oder HBT.
+
+### Zugang beantragen
+
+Der Zugriff ist beschränkt und wird nicht automatisch freigeschaltet. Laut HVV
+besteht kein grundsätzlicher Anspruch auf einen Zugang. Für die Beantragung:
+
+1. Die
+   [HVV-Zugangsseite und Nutzungsbedingungen](https://www.hvv.de/de/fahrplaene/abruf-fahrplaninfos/datenabruf)
+   lesen.
+2. Den Zugang über die dort angebotene E-Mail-Adresse beantragen.
+3. Im Antrag einen Ansprechpartner und eine kurze Beschreibung des Vorhabens
+   nennen. Für dieses Projekt passt beispielsweise: private, kostenfreie
+   Abfahrtsanzeige auf einem Raspberry Pi, verwendete Haltestellen und ein Abruf
+   alle 15 Sekunden.
+4. Nach Freigabe werden eine Geofox Application-ID und ein Passwort benötigt.
+5. Repository installieren und beide Werte bei der interaktiven Abfrage von
+   `./install.sh` eingeben.
+
+Die Zugangsdaten niemals in `config.json`, im Repository, in einem GitHub-Issue
+oder in einem Screenshot speichern. Der Installer legt sie geschützt unter
+`/etc/hvv-anzeiger.env` ab.
+
+### Nutzungs- und Betriebsgrenzen
+
+- Maßgeblich sind immer die aktuellen Bedingungen von HVV, HOCHBAHN und HBT.
+- Die Fahrplanauskunft muss für Endnutzer kostenfrei bleiben. Eine freiwillige
+  Unterstützung dieses Open-Source-Projekts schaltet keine Funktionen oder
+  Fahrplandaten frei.
+- Herkunft und Anbieter der Fahrplandaten müssen erkennbar sein. Datenquelle für
+  dieses Projekt ist Geofox/HVV.
+- Bei einer öffentlichen Bereitstellung die aktuellen Darstellungs- und
+  Hinweispflichten vollständig prüfen. Die HVV-Bedingungen nennen unter anderem
+  einen sichtbaren Link zu `www.hvv.de` und einen Hinweis `ohne Gewähr`. Das
+  kleine Display dieses privaten Zielsetups stellt diese Hinweise nicht
+  automatisch dar.
+- Für Vollständigkeit, Richtigkeit, Aktualität oder Verfügbarkeit der Daten gibt
+  es keine Garantie.
+- Geofox kann Zugriffe begrenzen. Laut
+  [GTI-Anwenderhandbuch](https://gti.geofox.de/html/GTIHandbuch_p.html)
+  kann ein Durchschnitt von mehr als einem API-Aufruf pro Sekunde zu einer
+  temporären Sperre führen. Der Standard dieses Projekts liegt mit einem
+  gemeinsamen Abruf alle 15 Sekunden deutlich darunter.
+- Das Anwenderhandbuch weist darauf hin, dass inaktive Konten nach einem Jahr
+  gelöscht werden können.
+
 ## Unterstütztes Setup
 
 ### Hardware
@@ -549,3 +612,16 @@ Bei jedem Push und Pull Request prüft GitHub Actions:
 - Shell-Skripte und systemd-Units
 - vollständige Installation und Rollback in einer isolierten Ubuntu-Umgebung
 - Paket-Build und Display-Vorschau
+
+## Projekt unterstützen
+
+Der HVV-Anzeiger bleibt frei verfügbar. Wer Entwicklung, Tests und Dokumentation
+freiwillig unterstützen möchte, kann das hier tun:
+
+[HVV-Anzeiger auf Ko-fi unterstützen](https://ko-fi.com/bema1991)
+
+Eine Unterstützung ist vollständig freiwillig und hat keinen Einfluss auf
+Geofox-Zugang, Funktionen oder Updates. Für jede Nutzung der Geofox-Daten haben
+die erteilten Zugangs- und Nutzungsbedingungen Vorrang; ob eine öffentliche
+Finanzierung oder Spendeneinbindung damit vereinbar ist, muss der Betreiber im
+Zweifel vorab mit dem Schnittstellenanbieter klären.

--- a/tests/test_project_artifacts.py
+++ b/tests/test_project_artifacts.py
@@ -17,6 +17,16 @@ class ProjectArtifactTest(unittest.TestCase):
         with Image.open(screenshot) as image:
             self.assertEqual(image.size, (320, 240))
 
+    def test_readme_documents_geofox_access_and_project_support(self) -> None:
+        readme = (ROOT / "README.md").read_text(encoding="utf-8")
+        self.assertIn("https://gti.geofox.de/", readme)
+        self.assertIn(
+            "https://www.hvv.de/de/fahrplaene/abruf-fahrplaninfos/datenabruf",
+            readme,
+        )
+        self.assertIn("https://gti.geofox.de/html/GTIHandbuch_p.html", readme)
+        self.assertIn("https://ko-fi.com/bema1991", readme)
+
     def test_installer_is_executable_and_syntax_is_checked_by_ci(self) -> None:
         installer = ROOT / "install.sh"
         mode = installer.stat().st_mode


### PR DESCRIPTION
## Kontext

Für die Installation werden Geofox-GTI-Zugangsdaten benötigt. Die README soll erklären, was Geofox GTI ist, wie der Zugang beantragt wird und welche offiziellen Nutzungsgrenzen zu beachten sind. Zusätzlich soll eine freiwillige Unterstützung des Projekts über Ko-fi möglich sein.

## Änderungen

- Ergänzt einen eigenen Abschnitt zur Geofox-GTI-Datenquelle und ihrer Rolle für Plan- und Echtzeitdaten.
- Verlinkt die offizielle GTI-Seite, das aktuelle Anwenderhandbuch und die HVV-Seite für individuelle Entwicklerprojekte.
- Beschreibt die Zugangsbeantragung mit Ansprechpartner, Projektbeschreibung, Application-ID und Passwort.
- Dokumentiert die sichere Übergabe an `install.sh` und warnt vor Speicherung in Repository, Konfiguration, Issues oder Screenshots.
- Fasst relevante Grenzen zusammen: keine garantierte Freigabe, kostenlose Fahrplanauskunft, Herkunftshinweis, fehlende Verfügbarkeitsgarantie, Abruflimit und mögliche Löschung inaktiver Konten.
- Weist auf zusätzliche Link- und Hinweispflichten bei öffentlicher Bereitstellung hin.
- Ergänzt den Ko-fi-Link `https://ko-fi.com/bema1991` als freiwillige Unterstützung ohne Einfluss auf Zugang, Funktionen oder Updates.
- Sichert alle vier Dokumentationslinks durch einen Artefakttest ab.

## Nutzer- und Produktwirkung

Neue Nutzer wissen vor der Installation, warum Zugangsdaten erforderlich sind, wo sie beantragt werden und welche Informationen der Antrag enthalten sollte. Betreiber können die offiziellen Bedingungen und technischen Unterlagen direkt erreichen.

## Risiken und Grenzen

- Zugang und Nutzungsbedingungen werden ausschließlich vom jeweiligen Schnittstellenanbieter bestimmt und können sich ändern.
- Das kleine Display rendert Link und `ohne Gewähr`-Hinweis nicht automatisch; vor öffentlichem Einsatz müssen die aktuellen Anforderungen geprüft und gegebenenfalls umgesetzt werden.
- Die Vereinbarkeit öffentlicher Finanzierung oder Spendeneinbindung mit einem konkreten Geofox-Zugang muss der Betreiber im Zweifel mit dem Schnittstellenanbieter klären.

## Verifikation

- Offizielle Geofox- und HVV-Seiten live geprüft.
- 102 Tests bestanden.
- 100 % Statement- und Branch-Coverage.
- Ruff und `git diff --check` bestanden.
- Linkziele werden durch einen neuen README-Artefakttest abgesichert.

## Review-Hinweise

Bitte insbesondere die Abgrenzung zwischen diesem unabhängigen Projekt und HVV/HOCHBAHN/HBT sowie die Formulierung zu öffentlicher Nutzung und freiwilliger Unterstützung prüfen.

This change has been created with the support of Codex. Please review carefully to confirm that the acceptance criteria are met.