### PR TITLE
A-1: Add liability disclaimer and station adjustment skill

### DIFF
--- a/.agents/skills/adjust-hvv-stations/SKILL.md
+++ b/.agents/skills/adjust-hvv-stations/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: adjust-hvv-stations
+description: Safely update the HVV-Anzeiger station, line, destination, station ID, and display-label configuration. Use when a user wants to add, remove, replace, or correct stops or route filters in config.example.json or an installed /opt/hvv-anzeiger/config.json.
+---
+
+# HVV-Haltestellen anpassen
+
+Ändere ausschließlich die gewünschten Haltestellen und Verbindungen. Bewahre
+API-, Display- und Nachtmodus-Einstellungen sowie Geofox-Zugangsdaten.
+
+## Ablauf
+
+1. Repository-Anweisungen und Git-Status prüfen. Bei Codeänderungen nie direkt
+   auf `main` arbeiten.
+2. Vom Nutzer je Verbindung Haltestelle, Stadt, Linie und Ziel erfassen.
+   Fehlende Stadt als `Hamburg` annehmen. Für jede Haltestelle ein eindeutiges
+   sichtbares Kürzel mit 1 bis 3 Zeichen wählen.
+3. Ziel bestimmen:
+   - Repository-Default: `config.example.json`
+   - installierter Raspberry Pi: `/opt/hvv-anzeiger/config.json`
+4. Geofox-ID nur übernehmen, wenn sie verlässlich bekannt oder bereits
+   konfiguriert ist. Andernfalls das Feld `id` weglassen; die Anwendung löst die
+   Haltestelle beim nächsten Start über Geofox auf. Niemals eine ID erraten.
+5. Eine temporäre JSON-Datei mit einem Array der gewünschten
+   Haltestellenobjekte erstellen. Keine Zugangsdaten darin speichern.
+6. Änderung zuerst ohne `--write` prüfen:
+
+   ```bash
+   python3 .agents/skills/adjust-hvv-stations/scripts/update_stations.py \
+     --config config.example.json \
+     --stations-file /tmp/hvv-stations.json
+   ```
+
+7. Die geprüfte Änderung anwenden:
+
+   ```bash
+   python3 .agents/skills/adjust-hvv-stations/scripts/update_stations.py \
+     --config config.example.json \
+     --stations-file /tmp/hvv-stations.json \
+     --write
+   ```
+
+   Bei einer installierten Konfiguration `sudo` verwenden. Das Skript legt vor
+   dem Überschreiben eine datierte Sicherung neben der Konfiguration an.
+8. `python3 -m json.tool <config>` und die Projekt-Tests ausführen. Bei einer
+   installierten Konfiguration zusätzlich eine Vorschau rendern.
+9. Nur auf ausdrücklichen Nutzerwunsch den laufenden Dienst neu starten:
+
+   ```bash
+   sudo systemctl restart hvv-anzeiger
+   ```
+
+10. Bei Repository-Defaults die Tabelle „Vorkonfigurierte Verbindungen“ in
+    `README.md` und betroffene Tests synchronisieren.
+
+## Format der Haltestellendatei
+
+```json
+[
+  {
+    "name": "Recknitzstraße",
+    "city": "Hamburg",
+    "id": "Master:82015",
+    "label": "R",
+    "routes": [
+      {
+        "line": "21",
+        "destination": "U Niendorf Nord"
+      }
+    ]
+  }
+]
+```
+
+`id` ist optional. Mindestens eine Haltestelle und je Haltestelle mindestens eine
+Linie-Ziel-Kombination angeben. Die Kürzel müssen eindeutig sein.
+
+## Sicherheitsregeln
+
+- `/etc/hvv-anzeiger.env` weder lesen noch verändern; sie enthält Geheimnisse.
+- Keine Geofox-Zugangsdaten in Prompts, Ausgaben, Konfigurationen oder Commits
+  übernehmen.
+- Nicht anhand ähnlich klingender Namen oder Ziele raten. Mehrdeutige
+  Haltestellen dem Nutzer zur Auswahl vorlegen oder eine bestätigte Geofox-ID
+  verlangen.
+- Vor dem Schreiben immer die Vorschau prüfen.
+- Eine Sicherung erst entfernen, wenn die Anzeige mit der neuen Konfiguration
+  erfolgreich läuft.

--- a/.agents/skills/adjust-hvv-stations/agents/openai.yaml
+++ b/.agents/skills/adjust-hvv-stations/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "HVV-Haltestellen anpassen"
+  short_description: "Haltestellen und Linien sicher konfigurieren"
+  default_prompt: "Use $adjust-hvv-stations to update the configured HVV stops, lines, and destinations safely."

--- a/.agents/skills/adjust-hvv-stations/scripts/update_stations.py
+++ b/.agents/skills/adjust-hvv-stations/scripts/update_stations.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Replace only the stations section of an HVV-Anzeiger configuration."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+import tempfile
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Haltestellen ersetzen, die vollständige Konfiguration validieren "
+            "und standardmäßig nur als Vorschau ausgeben."
+        )
+    )
+    parser.add_argument("--config", required=True, type=Path)
+    parser.add_argument("--stations-file", required=True, type=Path)
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="Validierte Konfiguration atomar schreiben und vorher sichern.",
+    )
+    return parser
+
+
+def _read_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValueError(f"Datei nicht gefunden: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Ungültiges JSON in {path}: {exc}") from exc
+
+
+def _stations(value: Any) -> list[dict[str, Any]]:
+    if isinstance(value, dict):
+        value = value.get("stations")
+    if not isinstance(value, list) or not value:
+        raise ValueError(
+            "Die Haltestellendatei muss ein nicht leeres JSON-Array oder "
+            "ein Objekt mit einem nicht leeren Feld 'stations' enthalten."
+        )
+    if not all(isinstance(item, dict) for item in value):
+        raise ValueError("Jede Haltestelle muss ein JSON-Objekt sein.")
+    return value
+
+
+def _project_root(config_path: Path) -> Path:
+    candidates = [config_path.resolve().parent, Path.cwd().resolve()]
+    candidates.extend(Path(__file__).resolve().parents)
+    for candidate in candidates:
+        if (candidate / "hvv_display" / "config.py").is_file():
+            return candidate
+    raise ValueError(
+        "Projektwurzel mit hvv_display/config.py wurde nicht gefunden."
+    )
+
+
+def _validate(config: dict[str, Any], root: Path) -> None:
+    sys.path.insert(0, str(root))
+    from hvv_display.config import ConfigError, load_config
+
+    with tempfile.TemporaryDirectory(prefix="hvv-config-") as directory:
+        candidate = Path(directory) / "config.json"
+        candidate.write_text(
+            json.dumps(config, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        try:
+            load_config(candidate)
+        except ConfigError as exc:
+            raise ValueError(f"Konfiguration ist ungültig: {exc}") from exc
+
+
+def _backup_path(config_path: Path) -> Path:
+    timestamp = datetime.now().astimezone().strftime("%Y%m%d-%H%M%S")
+    candidate = config_path.with_name(f"{config_path.name}.bak-{timestamp}")
+    counter = 1
+    while candidate.exists():
+        candidate = config_path.with_name(
+            f"{config_path.name}.bak-{timestamp}-{counter}"
+        )
+        counter += 1
+    return candidate
+
+
+def _write(config_path: Path, config: dict[str, Any]) -> Path:
+    backup = _backup_path(config_path)
+    shutil.copy2(config_path, backup)
+    payload = json.dumps(config, ensure_ascii=False, indent=2) + "\n"
+    temporary: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=config_path.parent,
+            prefix=f".{config_path.name}.",
+            delete=False,
+        ) as handle:
+            handle.write(payload)
+            temporary = Path(handle.name)
+        shutil.copymode(config_path, temporary)
+        temporary.replace(config_path)
+    except Exception:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+        raise
+    return backup
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    try:
+        raw_config = _read_json(args.config)
+        if not isinstance(raw_config, dict):
+            raise ValueError("Die Konfiguration muss ein JSON-Objekt sein.")
+        updated = dict(raw_config)
+        updated["stations"] = _stations(_read_json(args.stations_file))
+        _validate(updated, _project_root(args.config))
+        if args.write:
+            backup = _write(args.config, updated)
+            print(f"Konfiguration aktualisiert. Sicherung: {backup}")
+        else:
+            print(json.dumps(updated, ensure_ascii=False, indent=2))
+        return 0
+    except (OSError, ValueError) as exc:
+        print(f"Fehler: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/README.md
+++ b/README.md
@@ -433,6 +433,23 @@ Schreibweisen wie `Straße` und `Strasse` verglichen. Ein zusätzliches
 Verkehrsmittel-Präfix im Geofox-Ziel, beispielsweise `S Elbgaustraße`, wird
 ebenfalls berücksichtigt.
 
+### Haltestellen mit Codex anpassen
+
+Das Repository enthält den Skill `$adjust-hvv-stations`. Er kann verwendet
+werden, wenn Codex Haltestellen, Linien, Ziele oder Kürzel ändern soll, zum
+Beispiel:
+
+```text
+Nutze $adjust-hvv-stations und ersetze die vorkonfigurierten Verbindungen durch
+Linie 5 Richtung Hauptbahnhof ab Rathausmarkt.
+```
+
+Der Skill ändert nur den Haltestellenbereich, prüft die vollständige
+Konfiguration vor dem Schreiben und legt bei Änderungen an einer Installation
+eine Sicherung an. Eine unbekannte Geofox-ID wird nicht geraten, sondern beim
+nächsten Programmstart über Geofox aufgelöst. Zugangsdaten werden dabei weder
+gelesen noch in die Konfiguration übernommen.
+
 ### WLAN-Schnittstelle
 
 Der Dienst überwacht standardmäßig `wlan0`. Falls die WLAN-Schnittstelle anders
@@ -584,6 +601,28 @@ set +a
 - Geofox-Antworten sind auf 1 MiB begrenzt.
 - Python-Abhängigkeiten sind mit Versionen und SHA-256-Prüfsummen festgelegt.
 - GitHub Actions prüft Abhängigkeiten auf bekannte Schwachstellen.
+
+## Haftungsausschluss
+
+Dieses unabhängige Open-Source-Projekt wird ohne Zusicherung einer bestimmten
+Eigenschaft oder dauerhaften Verfügbarkeit bereitgestellt. Fahrplandaten,
+Echtzeitprognosen und Störungshinweise stammen von externen Anbietern und können
+unvollständig, verspätet oder fehlerhaft sein. Die Anzeige ist deshalb nicht als
+alleinige Grundlage für zeitkritische Reiseentscheidungen gedacht; im Zweifel
+die offiziellen HVV-Auskünfte prüfen.
+
+Installation, elektrische Verdrahtung und Betrieb erfolgen in eigener
+Verantwortung. Vor Arbeiten an Raspberry Pi und Display die Stromversorgung
+trennen und die Vorgaben der jeweiligen Hardwarehersteller beachten. Der
+Betreiber ist außerdem selbst dafür verantwortlich, die für seinen
+Geofox-Zugang geltenden Nutzungs-, Kennzeichnungs- und Datenschutzbedingungen
+einzuhalten.
+
+Soweit gesetzlich zulässig, haften die Projektverantwortlichen nicht für Schäden
+oder Folgeschäden aus Nutzung, Nichtverfügbarkeit oder Fehlfunktion der Software
+und der angezeigten Daten. Zwingende gesetzliche Haftung, insbesondere für
+Vorsatz, grobe Fahrlässigkeit sowie Schäden an Leben, Körper oder Gesundheit,
+bleibt unberührt. Dieser Hinweis ist keine Rechtsberatung.
 
 ## Grenzen
 

--- a/tests/test_project_artifacts.py
+++ b/tests/test_project_artifacts.py
@@ -26,6 +26,20 @@ class ProjectArtifactTest(unittest.TestCase):
         )
         self.assertIn("https://gti.geofox.de/html/GTIHandbuch_p.html", readme)
         self.assertIn("https://ko-fi.com/bema1991", readme)
+        self.assertIn("## Haftungsausschluss", readme)
+        self.assertIn("keine Rechtsberatung", readme)
+
+    def test_station_adjustment_skill_is_complete(self) -> None:
+        skill = ROOT / ".agents" / "skills" / "adjust-hvv-stations"
+        instructions = (skill / "SKILL.md").read_text(encoding="utf-8")
+        metadata = (skill / "agents" / "openai.yaml").read_text(encoding="utf-8")
+        script = skill / "scripts" / "update_stations.py"
+        self.assertIn("name: adjust-hvv-stations", instructions)
+        self.assertIn("--stations-file", instructions)
+        self.assertIn("config.example.json", instructions)
+        self.assertIn("/opt/hvv-anzeiger/config.json", instructions)
+        self.assertIn("$adjust-hvv-stations", metadata)
+        self.assertTrue(script.is_file())
 
     def test_installer_is_executable_and_syntax_is_checked_by_ci(self) -> None:
         installer = ROOT / "install.sh"

--- a/tests/test_station_skill_script.py
+++ b/tests/test_station_skill_script.py
@@ -1,0 +1,130 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = (
+    ROOT
+    / ".agents"
+    / "skills"
+    / "adjust-hvv-stations"
+    / "scripts"
+    / "update_stations.py"
+)
+
+
+class StationSkillScriptTest(unittest.TestCase):
+    def _run(self, *args: str) -> subprocess.CompletedProcess[str]:
+        # The executable and script path are repository-controlled test fixtures.
+        return subprocess.run(  # noqa: S603
+            [sys.executable, str(SCRIPT), *args],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_preview_replaces_only_stations(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            stations_path = Path(directory) / "stations.json"
+            stations_path.write_text(
+                json.dumps(
+                    [
+                        {
+                            "name": "Teststraße",
+                            "city": "Hamburg",
+                            "label": "T",
+                            "routes": [
+                                {
+                                    "line": "1",
+                                    "destination": "Testzentrum",
+                                }
+                            ],
+                        }
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            result = self._run(
+                "--config",
+                "config.example.json",
+                "--stations-file",
+                str(stations_path),
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        preview = json.loads(result.stdout)
+        original = json.loads(
+            (ROOT / "config.example.json").read_text(encoding="utf-8")
+        )
+        self.assertEqual(preview["api"], original["api"])
+        self.assertEqual(preview["display"], original["display"])
+        self.assertEqual(preview["night_shutdown"], original["night_shutdown"])
+        self.assertEqual(preview["stations"][0]["name"], "Teststraße")
+        self.assertNotIn("id", preview["stations"][0])
+
+    def test_write_creates_backup_and_valid_configuration(self) -> None:
+        original = json.loads(
+            (ROOT / "config.example.json").read_text(encoding="utf-8")
+        )
+        replacement = {
+            "stations": [
+                {
+                    "name": "Neue Haltestelle",
+                    "label": "NH",
+                    "routes": [{"line": "2", "destination": "Neues Ziel"}],
+                }
+            ]
+        }
+        with tempfile.TemporaryDirectory(dir=ROOT) as directory:
+            config_path = Path(directory) / "config.json"
+            stations_path = Path(directory) / "stations.json"
+            config_path.write_text(json.dumps(original), encoding="utf-8")
+            stations_path.write_text(json.dumps(replacement), encoding="utf-8")
+
+            result = self._run(
+                "--config",
+                str(config_path),
+                "--stations-file",
+                str(stations_path),
+                "--write",
+            )
+
+            backups = list(Path(directory).glob("config.json.bak-*"))
+            updated = json.loads(config_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Konfiguration aktualisiert", result.stdout)
+        self.assertEqual(len(backups), 1)
+        self.assertEqual(updated["stations"], replacement["stations"])
+
+    def test_invalid_station_input_is_rejected_without_writing(self) -> None:
+        with tempfile.TemporaryDirectory(dir=ROOT) as directory:
+            config_path = Path(directory) / "config.json"
+            stations_path = Path(directory) / "stations.json"
+            original = (ROOT / "config.example.json").read_text(encoding="utf-8")
+            config_path.write_text(original, encoding="utf-8")
+            stations_path.write_text("[]", encoding="utf-8")
+
+            result = self._run(
+                "--config",
+                str(config_path),
+                "--stations-file",
+                str(stations_path),
+                "--write",
+            )
+
+            unchanged = config_path.read_text(encoding="utf-8")
+            backups = list(Path(directory).glob("config.json.bak-*"))
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("nicht leeres JSON-Array", result.stderr)
+        self.assertEqual(unchanged, original)
+        self.assertEqual(backups, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Context

The project needs a clear liability boundary for third-party timetable data, hardware installation, and Geofox usage. Maintainers also need a repeatable, safe way to adapt the configured stops, lines, and destinations.

Related work: A-1

## What changed

- Added a German liability disclaimer covering external data quality, electrical installation, operator responsibilities, statutory liability exceptions, and the fact that it is not legal advice.
- Added the repository-local `$adjust-hvv-stations` Codex skill with discoverable UI metadata.
- Added a deterministic station-update helper that previews changes by default, preserves all non-station configuration, validates the complete result, writes atomically, and creates a dated backup.
- Documented how to invoke the skill from the README.
- Added automated tests for skill completeness, preview behavior, backups, validation, and unchanged settings.

## Why

The disclaimer makes the operating boundary understandable without implying that mandatory statutory liability can be excluded. The skill reduces configuration mistakes and prevents credentials or unrelated settings from being touched while adapting routes.

## User and product impact

Users can ask Codex to change the configured stops in a consistent workflow. Unknown Geofox station IDs are deliberately left unresolved instead of being guessed; the application resolves them through Geofox on startup. Existing runtime behavior is unchanged until a configuration is explicitly updated.

## Risks and limitations

- The disclaimer is general project documentation, not legal advice.
- Ambiguous stations still require a confirmed Geofox ID or user selection.
- Restarting the live service remains an explicit action.
- The local macOS installer smoke simulation uses Python 3.9 and cannot install the current cbor2 lock; the unchanged GitHub Actions smoke test uses the supported CI environment and is the authoritative installer check.

## Verification

- Official skill validator: passed
- 106 unit and integration tests: passed
- Statement and branch coverage: 100%
- Ruff: passed
- Python compile check: passed
- Package build: passed
- Bash syntax checks: passed
- Installer smoke test: pending GitHub Actions on a supported Python version

## Review notes

Please review the liability wording and the guardrails around installed `/opt/hvv-anzeiger/config.json` changes in particular.

This change has been created with the support of Codex. Please review carefully to confirm that the acceptance criteria are met.