### PR TITLE
A-1: Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,59 @@
+## Ticket / Referenz
+
+<!-- Jira-Ticket, GitHub-Issue oder andere Referenz verlinken. -->
+
+- Referenz:
+
+## Kontext
+
+<!-- Welches Problem oder welcher Bedarf wird adressiert? Warum ist die Änderung nötig? -->
+
+## Änderungen
+
+<!-- Die wichtigsten fachlichen und technischen Änderungen als kurze Liste. -->
+
+-
+
+## Produktwirkung
+
+<!-- Was ändert sich für Nutzer, Betreiber oder Mitwirkende?
+Bei keiner sichtbaren Wirkung ausdrücklich angeben. -->
+
+## Risiken und Grenzen
+
+<!-- Bekannte Risiken, Einschränkungen, Kompatibilität, Datenschutz,
+Sicherheit und bewusst ausgeschlossene Punkte. -->
+
+## Verifikation
+
+<!-- Nur tatsächlich ausgeführte Prüfungen markieren. Nicht anwendbare Punkte entfernen oder erklären. -->
+
+- [ ] Tests
+- [ ] Coverage
+- [ ] Ruff oder andere statische Prüfung
+- [ ] ShellCheck beziehungsweise Shell-Syntax
+- [ ] Paket-Build oder Installation
+- [ ] Manuelle Prüfung
+
+Ausgeführte Befehle und Ergebnisse:
+
+```text
+
+```
+
+## Screenshots oder Beispiele
+
+<!-- Bei sichtbaren Änderungen Vorher-/Nachher-Bilder oder ein nachvollziehbares
+Beispiel ergänzen. Andernfalls „Nicht erforderlich“. -->
+
+## Offene Punkte
+
+<!-- Bekannte Folgearbeiten oder „Keine“. -->
+
+## Review-Hinweise
+
+<!-- Worauf sollen Reviewer besonders achten? -->
+
+---
+
+This change has been created with the support of Codex. Please review carefully to confirm that the acceptance criteria are met.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,8 @@ Danach:
 
 Ein Pull Request muss die Motivation, die sichtbare Auswirkung, Risiken und die
 ausgeführten Prüfungen beschreiben. Er darf keine sachfremden Änderungen
-enthalten.
+enthalten. Das beim Öffnen automatisch eingeblendete Pull-Request-Template
+vollständig ausfüllen und nicht zutreffende Punkte kurz kennzeichnen.
 
 ## Lizenz der Beiträge
 

--- a/tests/test_project_artifacts.py
+++ b/tests/test_project_artifacts.py
@@ -102,6 +102,30 @@ class ProjectArtifactTest(unittest.TestCase):
         self.assertIn("[GNU General Public License Version 3](LICENSE)", readme)
         self.assertEqual(codeowners.strip().splitlines()[-1], "* @Ben1991")
 
+    def test_pull_request_template_covers_review_context(self) -> None:
+        template = (
+            ROOT / ".github" / "pull_request_template.md"
+        ).read_text(encoding="utf-8")
+        expected_sections = (
+            "## Ticket / Referenz",
+            "## Kontext",
+            "## Änderungen",
+            "## Produktwirkung",
+            "## Risiken und Grenzen",
+            "## Verifikation",
+            "## Screenshots oder Beispiele",
+            "## Offene Punkte",
+            "## Review-Hinweise",
+        )
+        positions = [template.index(section) for section in expected_sections]
+        self.assertEqual(positions, sorted(positions))
+        self.assertIn("- [ ] Tests", template)
+        self.assertIn("- [ ] Coverage", template)
+        self.assertIn(
+            "This change has been created with the support of Codex.",
+            template,
+        )
+
     def test_installer_is_executable_and_syntax_is_checked_by_ci(self) -> None:
         installer = ROOT / "install.sh"
         mode = installer.stat().st_mode


### PR DESCRIPTION
## Ticket / Referenz

- Referenz: A-1

## Kontext

Das Repository definiert den erwarteten PR-Inhalt bisher nur in CONTRIBUTING.md. Beim Öffnen eines Pull Requests fehlt eine direkt ausfüllbare, einheitliche Struktur.

## Änderungen

- fügt `.github/pull_request_template.md` hinzu
- deckt Referenz, Kontext, Änderungen, Produktwirkung, Risiken, Verifikation, Screenshots, offene Punkte und Review-Hinweise ab
- enthält eine Checkliste für tatsächlich ausgeführte Prüfungen
- enthält den vorgeschriebenen Codex-Hinweis
- verweist in CONTRIBUTING.md auf das automatisch eingeblendete Template
- schützt Aufbau und Pflichtbestandteile mit einem Artefakttest

## Produktwirkung

Neue Pull Requests erhalten automatisch eine konsistente, reviewerfreundliche Beschreibung. Risiken, Nutzerwirkung und reale Prüfergebnisse werden dadurch seltener vergessen.

## Risiken und Grenzen

Das Template erscheint automatisch bei neuen Pull Requests, sobald es auf `main` liegt. Bereits bestehende Pull Requests werden von GitHub nicht rückwirkend geändert.

## Verifikation

- [x] Tests
- [x] Coverage
- [x] Ruff oder andere statische Prüfung
- [ ] ShellCheck beziehungsweise Shell-Syntax
- [ ] Paket-Build oder Installation
- [x] Manuelle Prüfung

Ausgeführte Befehle und Ergebnisse:

```text
python -m unittest tests.test_project_artifacts -v: 11 Tests erfolgreich
coverage run -m unittest discover -s tests -v: 109 Tests erfolgreich
coverage report: 100 % Statements und Branches
ruff check .: erfolgreich
git diff --check: erfolgreich
```

## Screenshots oder Beispiele

Nicht erforderlich; es handelt sich um ein Markdown-Template.

## Offene Punkte

Keine.

## Review-Hinweise

Bitte prüfen, ob die Abschnitte für externe Beitragende verständlich und für kleine wie größere Änderungen ausreichend sind.

---

This change has been created with the support of Codex. Please review carefully to confirm that the acceptance criteria are met.