### PR TITLE
A-1: Use Ko-fi button in README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HVV-Anzeiger für Raspberry Pi
 
-<sub>☕ Projekt unterstützen: <a href="https://ko-fi.com/bema1991">Ko-fi</a></sub>
+[![Ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/U3D523YISZ)
 
 [![CI](https://github.com/Ben1991/hvv-anzeiger/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Ben1991/hvv-anzeiger/actions/workflows/ci.yml)
 [![Lizenz: GPL-3.0-only](https://img.shields.io/badge/Lizenz-GPL--3.0--only-blue.svg)](LICENSE)


### PR DESCRIPTION
## Context

The README header currently uses a small text-only Ko-fi link.

## What changed

- Replaced the text link at the top of the README with the official Ko-fi GitHub button.
- Uses the provided Ko-fi target `https://ko-fi.com/U3D523YISZ`.
- Kept the detailed support section unchanged.

## Product impact

The project support link is more visible and visually consistent with Ko-fi. No application behavior changes.

## Risks and limitations

The button image is loaded from Ko-fi when GitHub renders the README. If that external image is unavailable, the linked alt text remains.

## Verification

- `git diff --check`
- Confirmed that only `README.md` changed
- Confirmed the image and target URLs in the rendered Markdown source

## Jira alignment

Documentation-only project maintenance under A-1.

This change has been created with the support of Codex. Please review carefully to confirm that the acceptance criteria are met.