### PR TITLE
A-1: Clarify Raspberry Pi OS and model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,12 @@
 [![CI](https://github.com/Ben1991/hvv-anzeiger/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Ben1991/hvv-anzeiger/actions/workflows/ci.yml)
 [![Lizenz: GPL-3.0-only](https://img.shields.io/badge/Lizenz-GPL--3.0--only-blue.svg)](LICENSE)
 
-Eine kompakte Abfahrtsanzeige für einen Raspberry Pi Zero 2 W und ein
-2,2-Zoll-ILI9341-SPI-Display. Sie lädt alle 15 Sekunden aktuelle
-Geofox-Prognosen, filtert die gewünschten Busverbindungen und sortiert sie
-haltestellenübergreifend nach der erwarteten Abfahrtszeit.
+Eine kompakte Abfahrtsanzeige für einen Raspberry Pi Zero 2 W oder ein
+kompatibles Raspberry-Pi-Modell mit 40-Pin-GPIO und ein
+2,2-Zoll-ILI9341-SPI-Display. Sie läuft ohne grafische Oberfläche auf
+Raspberry Pi OS Lite, lädt alle 15 Sekunden aktuelle Geofox-Prognosen, filtert
+die gewünschten Busverbindungen und sortiert sie haltestellenübergreifend nach
+der erwarteten Abfahrtszeit.
 
 ![Beispielansicht der HVV-Abfahrtsanzeige](docs/hvv-anzeiger-preview.png)
 
@@ -94,10 +96,12 @@ Haltestelle eine Abfahrt stammt. Alle Verbindungen lassen sich in
 
 ### Hardware-Einkauf
 
-Die folgenden Amazon.de-Suchlinks führen zu passenden Produktkategorien. Vor
-dem Kauf die technischen Angaben des konkreten Angebots prüfen; insbesondere
-Controller, Auflösung, SPI-Anschluss, 3,3-V-Logik und Netzteilleistung müssen
-zum unten dokumentierten Aufbau passen.
+Die folgenden Amazon.de-Suchlinks führen zu passenden Produktkategorien für
+das Referenzsetup mit Raspberry Pi Zero 2 W. Vor dem Kauf die technischen
+Angaben des konkreten Angebots prüfen; insbesondere Controller, Auflösung,
+SPI-Anschluss, 3,3-V-Logik und Netzteilleistung müssen zum unten dokumentierten
+Aufbau passen. Für ein anderes Raspberry-Pi-Modell ist das jeweils dafür
+vorgesehene Netzteil erforderlich.
 
 | Komponente | Amazon.de-Suche | Worauf achten? |
 |---|---|---|
@@ -115,8 +119,50 @@ zum unten dokumentierten Aufbau passen.
 
 ### Unterstütztes Zielsystem
 
-- [Raspberry Pi Zero 2 W (Affiliate-Link)](https://www.amazon.de/s?k=Raspberry+Pi+Zero+2+W&tag=bema19910e-21)
-- Raspberry Pi OS Lite Bookworm, 64 Bit empfohlen
+#### Betriebssysteme
+
+Raspberry Pi OS Lite ist das empfohlene Betriebssystem. Es benötigt keine
+grafische Oberfläche und passt damit besonders gut zum dauerhaft und
+headless betriebenen Anzeiger. Der Installer verwendet nur Werkzeuge, die in
+Raspberry Pi OS vorhanden sind: `apt`, `raspi-config` und `systemd`.
+
+| Betriebssystem | Status | Hinweis |
+|---|---|---|
+| Raspberry Pi OS Lite, 64 Bit, Trixie | empfohlen | aktuelles schlankes Zielsystem für Raspberry Pi Zero 2 W und die unten aufgeführten 64-Bit-Modelle |
+| Raspberry Pi OS Lite, 32 Bit, Trixie | unterstützt | sinnvoll, wenn ein kleinerer Speicherbedarf wichtiger ist; auf den unten aufgeführten Modellen muss `uname -m` den Wert `armv7l` liefern |
+| Raspberry Pi OS Legacy Lite, 64 oder 32 Bit, Bookworm | unterstützt | weiterhin geeignet, solange Raspberry Pi die jeweilige Ausgabe mit Sicherheitsupdates versorgt |
+| Raspberry Pi OS mit Desktop oder Full, Trixie beziehungsweise Bookworm | unterstützt | technisch derselbe Installationsweg; Desktop und Zusatzprogramme werden für die Anzeige nicht benötigt |
+| Raspberry Pi OS Bullseye oder älter | nicht unterstützt | die mitgelieferte Python-Version erfüllt die Anforderung Python 3.10 oder neuer nicht zuverlässig |
+| Ubuntu, allgemeines Debian und andere Distributionen | nicht unterstützt | der Installer setzt die Raspberry-Pi-spezifischen Werkzeuge, Gruppen und SPI-Konfiguration voraus |
+
+Raspberry Pi stellt
+[Raspberry Pi OS Lite in 64- und 32-Bit-Ausgaben](https://www.raspberrypi.com/software/operating-systems/)
+bereit. Die
+[offizielle Betriebssystemdokumentation](https://www.raspberrypi.com/documentation/computers/os.html)
+erklärt die Unterschiede zwischen Lite, Desktop und Full. Keine
+Desktop-Oberfläche zu installieren spart Speicherplatz und Hintergrundlast;
+die Displayausgabe selbst funktioniert direkt über SPI.
+
+#### Raspberry-Pi-Modelle
+
+| Modell | Status | Hinweis |
+|---|---|---|
+| [Raspberry Pi Zero 2 W (Affiliate-Link)](https://www.amazon.de/s?k=Raspberry+Pi+Zero+2+W&tag=bema19910e-21) | empfohlen und hardwaregetestet | Referenzsetup; 64-Bit Raspberry Pi OS Lite empfohlen |
+| Raspberry Pi 3A+, 3B und 3B+ | kompatibel by design | 40-Pin-GPIO, SPI0, WLAN und unterstützte ARM-Architektur; nicht im Projekt hardwaregetestet |
+| Raspberry Pi 4B und Raspberry Pi 400 | kompatibel by design | 40-Pin-GPIO, SPI0, WLAN und unterstützte ARM-Architektur; eigenes geeignetes Netzteil erforderlich und nicht im Projekt hardwaregetestet |
+| Raspberry Pi 2 | nicht als Komplettsetup unterstützt | kein integriertes WLAN und daher zusätzliche Hardware sowie Konfiguration erforderlich |
+| Raspberry Pi Zero, Zero W und Raspberry Pi 1 | nicht unterstützt | ARMv6 liegt außerhalb der für die Hardwaretreiber festgelegten Architekturen `armv7l` und `aarch64` |
+| Raspberry Pi 5, 500, 500+ und Compute Module 5 | nicht unterstützt | der aktuelle GPIO-Treiberpfad des Projekts ist nicht für die RP1-Hardware freigegeben |
+| Compute Modules und Raspberry Pi Pico | nicht unterstützt | Compute Modules benötigen ein trägerspezifisches GPIO-Setup; Pico-Modelle führen kein Raspberry Pi OS aus |
+
+„Kompatibel by design“ bedeutet: Softwarearchitektur, 40-Pin-Belegung und
+SPI-Anbindung passen zum Projekt, es existiert aber kein Hardwaretest dieses
+Repositories auf dem jeweiligen Modell. Fehlerberichte und bestätigte
+Installationen sind als
+[GitHub-Issue](https://github.com/Ben1991/hvv-anzeiger/issues) willkommen.
+
+#### Weitere Voraussetzungen
+
 - Python 3.10 oder neuer
 - [microSD-Karte (Affiliate-Link)](https://www.amazon.de/s?k=microSD+32GB+High+Endurance&tag=bema19910e-21)
 - [zuverlässiges 5-V-Netzteil mit mindestens 2 A (Affiliate-Link)](https://www.amazon.de/s?k=5V+2A+Micro+USB+Netzteil+Raspberry+Pi+Zero+2+W&tag=bema19910e-21)
@@ -126,11 +172,8 @@ zum unten dokumentierten Aufbau passen.
 - gültige Geofox-GTI-Zugangsdaten
 - Terminal- oder SSH-Zugang zum Raspberry Pi
 
-Andere Raspberry-Pi-Modelle können potenziell ebenfalls funktionieren, gehören
-aber nicht zum dokumentierten und getesteten Zielsetup. Getestet wurde das
-Projekt auf einem Raspberry Pi Zero 2 W. Pinbelegung, Spannungsversorgung,
-Hintergrundbeleuchtung und Farbreihenfolge müssen zum konkreten Display-Modul
-passen.
+Pinbelegung, Spannungsversorgung, Hintergrundbeleuchtung und Farbreihenfolge
+müssen zum konkreten Display-Modul passen.
 
 ## Geofox-Zugang beantragen
 

--- a/install.sh
+++ b/install.sh
@@ -108,8 +108,7 @@ command -v sudo >/dev/null 2>&1 || fail "sudo wurde nicht gefunden."
 command -v apt-get >/dev/null 2>&1 ||
   fail "Dieses Skript benötigt Raspberry Pi OS (Lite oder Desktop)."
 command -v raspi-config >/dev/null 2>&1 || fail "raspi-config wurde nicht gefunden."
-command -v python3 >/dev/null 2>&1 || fail "Python 3 wurde nicht gefunden."
-python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 10))' ||
+sudo -H python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 10))' ||
   fail "Python 3.10 oder neuer ist erforderlich."
 
 echo "[1/9] Systempakete installieren"

--- a/install.sh
+++ b/install.sh
@@ -105,8 +105,12 @@ if [[ "${EUID}" -eq 0 ]]; then
 fi
 
 command -v sudo >/dev/null 2>&1 || fail "sudo wurde nicht gefunden."
-command -v apt-get >/dev/null 2>&1 || fail "Dieses Skript benötigt Raspberry Pi OS/Debian."
+command -v apt-get >/dev/null 2>&1 ||
+  fail "Dieses Skript benötigt Raspberry Pi OS (Lite oder Desktop)."
 command -v raspi-config >/dev/null 2>&1 || fail "raspi-config wurde nicht gefunden."
+command -v python3 >/dev/null 2>&1 || fail "Python 3 wurde nicht gefunden."
+python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 10))' ||
+  fail "Python 3.10 oder neuer ist erforderlich."
 
 echo "[1/9] Systempakete installieren"
 sudo apt-get update

--- a/tests/test_project_artifacts.py
+++ b/tests/test_project_artifacts.py
@@ -93,6 +93,11 @@ class ProjectArtifactTest(unittest.TestCase):
         )
         self.assertIn("sys.version_info < (3, 10)", installer)
         self.assertIn("Python 3.10 oder neuer ist erforderlich", installer)
+        self.assertIn(
+            "sudo -H python3 -c 'import sys; "
+            "raise SystemExit(sys.version_info < (3, 10))'",
+            installer,
+        )
         self.assertNotIn("Raspberry Pi OS/Debian", installer)
 
     def test_station_adjustment_skill_is_complete(self) -> None:

--- a/tests/test_project_artifacts.py
+++ b/tests/test_project_artifacts.py
@@ -69,6 +69,32 @@ class ProjectArtifactTest(unittest.TestCase):
         self.assertIn("## Haftungsausschluss", readme)
         self.assertIn("keine Rechtsberatung", readme)
 
+    def test_readme_defines_supported_os_and_raspberry_pi_models(self) -> None:
+        readme = (ROOT / "README.md").read_text(encoding="utf-8")
+        installer = (ROOT / "install.sh").read_text(encoding="utf-8")
+
+        for expected in (
+            "Raspberry Pi OS Lite, 64 Bit, Trixie",
+            "Raspberry Pi OS Lite, 32 Bit, Trixie",
+            "Raspberry Pi OS Legacy Lite, 64 oder 32 Bit, Bookworm",
+            "Raspberry Pi Zero 2 W",
+            "Raspberry Pi 3A+, 3B und 3B+",
+            "Raspberry Pi 4B und Raspberry Pi 400",
+            "Raspberry Pi Zero, Zero W und Raspberry Pi 1",
+            "Raspberry Pi 5, 500, 500+ und Compute Module 5",
+            "kompatibel by design",
+        ):
+            with self.subTest(expected=expected):
+                self.assertIn(expected, readme)
+
+        self.assertIn(
+            "Raspberry Pi OS (Lite oder Desktop)",
+            installer,
+        )
+        self.assertIn("sys.version_info < (3, 10)", installer)
+        self.assertIn("Python 3.10 oder neuer ist erforderlich", installer)
+        self.assertNotIn("Raspberry Pi OS/Debian", installer)
+
     def test_station_adjustment_skill_is_complete(self) -> None:
         skill = ROOT / ".agents" / "skills" / "adjust-hvv-stations"
         instructions = (skill / "SKILL.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Kontext

Die README nannte bisher nur Raspberry Pi OS Lite Bookworm 64 Bit und ließ offen, welche aktuellen OS-Ausgaben und Raspberry-Pi-Modelle tatsächlich unterstützt oder lediglich potenziell kompatibel sind.

## Änderungen

- Dokumentiert Raspberry Pi OS Lite als empfohlenes headless Zielsystem ohne Desktop-Abhängigkeit.
- Listet Trixie Lite in 64 und 32 Bit, Legacy Bookworm sowie Desktop/Full mit klaren Supportstufen.
- Trennt hardwaregetesteten Zero 2 W, konzeptionell kompatible Pi-3/Pi-4-Modelle und nicht unterstützte Modelle.
- Erklärt Grenzen für ARMv6, RP1/Pi 5, Compute Modules und alternative Distributionen.
- Ergänzt offizielle Raspberry-Pi-Quellen für OS-Ausgaben und Editionen.
- Prüft im Installer Python >= 3.10 frühzeitig und nennt Raspberry Pi OS Lite/Desktop in der Fehlermeldung.
- Fügt eine Spezifikation hinzu, die die Supportmatrix und Installer-Anforderungen gegen unbeabsichtigte Änderungen absichert.

## Grund und Produktwirkung

Nutzer können vor Installation oder Hardwarekauf erkennen, welches Setup empfohlen, unterstützt, nur kompatibel-by-design oder ausgeschlossen ist. Raspberry Pi OS Lite ist jetzt ausdrücklich als primärer Installationsweg beschrieben.

## Risiken und Grenzen

- Nur der Raspberry Pi Zero 2 W ist im Projekt hardwaregetestet. Pi 3 und Pi 4 sind aufgrund Architektur, 40-Pin-GPIO, SPI0 und WLAN kompatibel-by-design, aber nicht als Hardwaretest bestätigt.
- Raspberry Pi 5/500 und CM5 bleiben wegen des aktuellen GPIO-Treiberpfads ausgeschlossen.
- Der reale Displaybetrieb und die GPIO-Treiber auf Trixie können nicht in GitHub Actions emuliert werden.

## Verifikation

- 110 Unit- und Integrationstests erfolgreich
- 100 % Coverage
- Ruff erfolgreich
- Bash-Syntax und ShellCheck erfolgreich
- Installer-Smoke-Test durchläuft Installation und Dienstaktivierung; die abschließende Linux-spezifische `stat -c`-Prüfung ist lokal auf macOS nicht verfügbar und wird durch GitHub CI auf Ubuntu abgedeckt
- `git diff --check` erfolgreich

## Ticket / Referenz

Projektpflege unter A-1.

This change has been created with the support of Codex. Please review carefully to confirm that the acceptance criteria are met.