### PR TITLE
fix: make install directory accessible and note tested OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ Installationen sind als
 Pinbelegung, Spannungsversorgung, Hintergrundbeleuchtung und Farbreihenfolge
 müssen zum konkreten Display-Modul passen.
 
+Die Installation wurde dabei auf Raspberry Pi OS Bookworm 64 Bit geprüft.
+
 ## Geofox-Zugang beantragen
 
 ### Datenquelle

--- a/install.sh
+++ b/install.sh
@@ -193,6 +193,7 @@ else
 fi
 sudo chown -R root:root "$STAGING_DIR"
 sudo chown -R "$APP_USER:$APP_GROUP" "$STAGING_DIR/var"
+sudo chmod 0755 "$STAGING_DIR"
 sudo chmod 0750 "$STAGING_DIR/var"
 sudo chmod 0644 "$STAGING_DIR/config.json"
 
@@ -241,6 +242,7 @@ fi
 SWITCHED=1
 sudo mv "$STAGING_DIR" "$APP_DIR"
 STAGING_DIR=""
+sudo chmod 0755 "$APP_DIR"
 # Console scripts contain the absolute venv path. Reinstalling the local package
 # after the move rewrites their shebangs to the final application directory.
 sudo -H "$APP_DIR/.venv/bin/python" -m pip install \

--- a/tests/install-smoke.sh
+++ b/tests/install-smoke.sh
@@ -101,6 +101,7 @@ printf 'smoke-application\nsmoke-password\n' | "$SOURCE_DIR/install.sh"
 
 test -x "$APP_DIR/.venv/bin/hvv-anzeiger"
 test -x "$APP_DIR/.venv/bin/hvv-preview"
+test "$(stat -c '%a' "$APP_DIR")" = "755"
 "$APP_DIR/.venv/bin/hvv-preview" "$ROOT/post-install-preview.png"
 test -s "$ROOT/post-install-preview.png"
 "$APP_DIR/.venv/bin/hvv-anzeiger" --help >/dev/null


### PR DESCRIPTION
This PR fixes the installer so the service user can enter the final install directory after activation, which prevents the systemd CHDIR failure seen on Raspberry Pi OS 64-bit. It also adds a README note that the setup was tested on Raspberry Pi OS Bookworm 64-bit on the Zero 2 W.