### PR TITLE
fix: avoid service chdir failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ Raspberry Pi OS Lite ist das empfohlene Betriebssystem. Es benötigt keine
 grafische Oberfläche und passt damit besonders gut zum dauerhaft und
 headless betriebenen Anzeiger. Der Installer verwendet nur Werkzeuge, die in
 Raspberry Pi OS vorhanden sind: `apt`, `raspi-config` und `systemd`.
+Er kommt außerdem ohne ein festes Arbeitsverzeichnis aus und ist deshalb
+nicht auf ein Lite-Image beschränkt.
 
 | Betriebssystem | Status | Hinweis |
 |---|---|---|

--- a/systemd/hvv-anzeiger.service
+++ b/systemd/hvv-anzeiger.service
@@ -10,11 +10,10 @@ WatchdogSec=90s
 User=hvv-anzeiger
 Group=hvv-anzeiger
 SupplementaryGroups=spi gpio
-WorkingDirectory=/opt/hvv-anzeiger
 EnvironmentFile=/etc/hvv-anzeiger.env
 Environment=PYTHONUNBUFFERED=1
 Environment=HVV_WIFI_INTERFACE=wlan0
-ExecStart=/opt/hvv-anzeiger/.venv/bin/python -m hvv_display --config /opt/hvv-anzeiger/config.json
+ExecStart=/opt/hvv-anzeiger/.venv/bin/python -m hvv_display --config /opt/hvv-anzeiger/config.json --cache /opt/hvv-anzeiger/var/stations.json
 Restart=always
 RestartSec=10
 UMask=0077

--- a/tests/test_project_artifacts.py
+++ b/tests/test_project_artifacts.py
@@ -209,6 +209,11 @@ class ProjectArtifactTest(unittest.TestCase):
         self.assertIn("ReadWritePaths=/opt/hvv-anzeiger/var", service)
         self.assertIn("User=hvv-anzeiger", service)
         self.assertIn("Group=hvv-anzeiger", service)
+        self.assertNotIn("WorkingDirectory=", service)
+        self.assertIn(
+            "--cache /opt/hvv-anzeiger/var/stations.json",
+            service,
+        )
         self.assertNotIn("GEOFOX_PASSWORD=", service)
 
     def test_dependencies_are_locked_with_hashes_and_audited_in_ci(self) -> None:


### PR DESCRIPTION
This PR removes the service's dependency on a fixed working directory and passes the stations cache as an absolute path. That avoids the systemd CHDIR failure seen during installation on Raspberry Pi OS 64-bit. The README is also updated to note that the installer is not limited to a Lite image.