### PR TITLE
release: prepare version 0.2.1 / V2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ der erwarteten Abfahrtszeit.
 
 ## Release Notes
 
+### Version 0.2.1 / V2.1
+
+- Weboberfläche im lokalen Netzwerk unter `http://<raspberry-pi-ip>:8080`
+- automatischer Start der Weboberfläche bei Installation und nach jedem Reboot
+- Standard-Anmeldung `hvv-anzeiger` / `hvv-anzeiger` für die Ersteinrichtung
+- Webpasswort in der Einstellungsseite änderbar; gespeichert wird nur ein
+  gesalzener Hash
+- README mit Hinweisen zum Deaktivieren und späteren Reaktivieren des
+  Webdienst-Autostarts
+
 ### Version 0.2.0 / V2
 
 - lokale Weboberfläche mit Abfahrtsanzeige im Display-Stil

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hvv-anzeiger"
-version = "0.2.0"
+version = "0.2.1"
 description = "HVV departure display for a Raspberry Pi and ILI9341 TFT"
 readme = "README.md"
 license = "GPL-3.0-only"


### PR DESCRIPTION
## Release 0.2.1 / V2.1

- dokumentiert den Zugriff auf die Weboberfläche über die Raspberry-Pi-IP im lokalen Netzwerk
- dokumentiert Webdienst-Autostart, Deaktivierung und Reaktivierung
- dokumentiert Standard-Anmeldung und Passwortänderung
- erhöht die Paketversion auf 0.2.1

## Prüfung

- `git diff --check` erfolgreich
- GitHub-CI prüft Python 3.10, 3.11, 3.13, Shell-Installer und CodeQL