### PR TITLE
fix: reliably restart web service after install and update

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,33 @@ Später lässt sie sich wieder aktivieren:
 sudo systemctl enable --now hvv-anzeiger-web
 ```
 
+### Weboberfläche: Verbindung abgelehnt
+
+Wenn `http://<raspberry-pi-ip>:8080` mit „Verbindung abgelehnt“ antwortet,
+läuft der Webdienst meist noch nicht oder eine aktualisierte systemd-Unit ist
+noch nicht geladen. Die folgenden Befehle laden die Unit neu, aktivieren den
+Autostart und starten den Dienst mit der aktuellen Konfiguration:
+
+```bash
+sudo systemctl status hvv-anzeiger-web --no-pager
+sudo ss -ltnp | grep 8080
+sudo systemctl enable --now hvv-anzeiger-web
+sudo systemctl daemon-reload
+sudo systemctl restart hvv-anzeiger-web
+sudo systemctl status hvv-anzeiger-web --no-pager
+```
+
+Die Ausgabe von `ss` sollte eine Bindung an `0.0.0.0:8080` zeigen. Fehlt sie
+oder bleibt der Dienst in `failed`, zeigt das Journal die Ursache:
+
+```bash
+sudo journalctl -u hvv-anzeiger-web -n 80 --no-pager
+```
+
+Nach einem Update führt `update.sh` das Neuladen und den Neustart automatisch
+durch. Die Adresse muss die tatsächliche Raspberry-Pi-IP enthalten, zum
+Beispiel `http://192.168.178.51:8080`.
+
 Die neue Installation wird in einem separaten Verzeichnis vorbereitet und
 geprüft, bevor sie die laufende Version ersetzt. Startet der neue Dienst nicht,
 stellt der Installer Anwendung, Zugangsdaten und systemd-Konfiguration auf den

--- a/install.sh
+++ b/install.sh
@@ -273,13 +273,17 @@ fi
 echo "[9/9] Autostart aktivieren und Ergebnis prüfen"
 sudo systemctl daemon-reload
 sudo systemctl enable "$SERVICE_NAME"
-sudo systemctl enable --now "$WEB_SERVICE"
+sudo systemctl enable "$WEB_SERVICE"
 sudo systemctl enable --now "$LOG_CLEANUP_TIMER"
 sudo systemctl restart "$SERVICE_NAME" ||
   fail "Der neue Dienst konnte nicht gestartet werden."
+sudo systemctl restart "$WEB_SERVICE" ||
+  fail "Die Weboberfläche konnte nicht gestartet werden."
 sleep 2
 sudo systemctl is-active --quiet "$SERVICE_NAME" ||
   fail "Der neue Dienst ist nach dem Start nicht aktiv."
+sudo systemctl is-active --quiet "$WEB_SERVICE" ||
+  fail "Die Weboberfläche ist nach dem Start nicht aktiv."
 
 INSTALL_SUCCEEDED=1
 if [[ -e "$BACKUP_DIR" ]]; then
@@ -300,6 +304,8 @@ printf "  %-24s %s\n" "Anwendung" "$APP_DIR"
 printf "  %-24s %s\n" "Geofox-Zugangsdaten" "$ENV_FILE (root:root, 0600)"
 printf "  %-24s %s\n" "Dienst" "$(systemctl is-active "$SERVICE_NAME")"
 printf "  %-24s %s\n" "Autostart" "$(systemctl is-enabled "$SERVICE_NAME")"
+printf "  %-24s %s\n" "Weboberfläche" "$(systemctl is-active "$WEB_SERVICE")"
+printf "  %-24s %s\n" "Web-Autostart" "$(systemctl is-enabled "$WEB_SERVICE")"
 printf "  %-24s %s\n" "Log-Bereinigung" "$(systemctl is-active "$LOG_CLEANUP_TIMER")"
 if [[ -e /dev/spidev0.0 ]]; then
   printf "  %-24s %s\n" "SPI" "/dev/spidev0.0 verfügbar"

--- a/tests/test_project_artifacts.py
+++ b/tests/test_project_artifacts.py
@@ -176,7 +176,9 @@ class ProjectArtifactTest(unittest.TestCase):
         installer_text = installer.read_text(encoding="utf-8")
         self.assertIn('systemctl stop "$SERVICE_NAME"', installer_text)
         self.assertIn('enable --now "$LOG_CLEANUP_TIMER"', installer_text)
-        self.assertIn('enable --now "$WEB_SERVICE"', installer_text)
+        self.assertIn('enable "$WEB_SERVICE"', installer_text)
+        self.assertIn('restart "$WEB_SERVICE"', installer_text)
+        self.assertIn('is-active --quiet "$WEB_SERVICE"', installer_text)
         self.assertIn('APP_USER="hvv-anzeiger"', installer_text)
         self.assertIn('systemctl enable "$SERVICE_NAME"', installer_text)
         self.assertIn("--require-hashes", installer_text)
@@ -196,6 +198,10 @@ class ProjectArtifactTest(unittest.TestCase):
             encoding="utf-8"
         )
         self.assertIn("tests/install-smoke.sh", workflow)
+        update_script = (ROOT / "update.sh").read_text(encoding="utf-8")
+        self.assertIn('systemctl daemon-reload', update_script)
+        self.assertIn('systemctl restart "$WEB_SERVICE"', update_script)
+        self.assertIn('systemctl is-active --quiet "$WEB_SERVICE"', update_script)
 
     def test_systemd_service_uses_protected_environment_file(self) -> None:
         service = (ROOT / "systemd" / "hvv-anzeiger.service").read_text(

--- a/update.sh
+++ b/update.sh
@@ -2,6 +2,7 @@
 set -Eeuo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+WEB_SERVICE="hvv-anzeiger-web.service"
 cd "$SCRIPT_DIR"
 
 if [[ "$(id -u)" -eq 0 ]]; then
@@ -24,4 +25,20 @@ git fetch origin --tags
 git pull --ff-only origin main
 
 echo "Installiere die neue Version ..."
-exec "$SCRIPT_DIR/install.sh"
+"$SCRIPT_DIR/install.sh"
+
+# A changed systemd unit is not necessarily restarted by enable --now when an
+# older instance is already active. Reload and restart explicitly so the web
+# service uses the just-installed bind address and configuration.
+echo "Aktualisiere und prüfe den Webdienst ..."
+sudo systemctl daemon-reload
+sudo systemctl enable "$WEB_SERVICE"
+sudo systemctl restart "$WEB_SERVICE" || {
+  echo "Fehler: Die Weboberfläche konnte nach dem Update nicht gestartet werden." >&2
+  exit 1
+}
+sudo systemctl is-active --quiet "$WEB_SERVICE" || {
+  echo "Fehler: Die Weboberfläche ist nach dem Update nicht aktiv." >&2
+  exit 1
+}
+echo "Weboberfläche ist aktiv und für den Autostart eingerichtet."


### PR DESCRIPTION
install.sh lädt systemd neu, aktiviert den Webdienst, startet ihn ausdrücklich neu und prüft seinen Status. update.sh führt dieselbe Reload-, Restart- und Statusprüfung nach Updates aus. Installer-Ausgabe zeigt Webdienst und Web-Autostart. README dokumentiert die Fehlerbehebung für Verbindung abgelehnt. Projektartefakt-Tests decken die neuen Service-Schritte ab. Geprüft: git diff --check und Bash-Syntaxprüfung mit Git Bash; vollständige Tests laufen in GitHub Actions.