### PR TITLE
fix: save web configuration under systemd protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,21 @@ Nach einem Update führt `update.sh` das Neuladen und den Neustart automatisch
 durch. Die Adresse muss die tatsächliche Raspberry-Pi-IP enthalten, zum
 Beispiel `http://192.168.178.51:8080`.
 
+Wenn die Oberfläche erreichbar ist, das Speichern aber mit `Read-only file
+system` für eine Datei wie `.config.json.…` fehlschlägt, läuft noch eine alte
+Installation. Das aktuelle Update installieren und die Web-Unit neu laden:
+
+```bash
+cd ~/hvv-anzeiger
+./update.sh
+sudo systemctl daemon-reload
+sudo systemctl restart hvv-anzeiger-web
+```
+
+Die aktuelle Version behandelt diese systemd-Einschränkung beim Speichern
+automatisch und schreibt die bereits freigegebene `config.json` direkt, wenn
+keine temporäre Nachbardatei angelegt werden darf.
+
 Die neue Installation wird in einem separaten Verzeichnis vorbereitet und
 geprüft, bevor sie die laufende Version ersetzt. Startet der neue Dienst nicht,
 stellt der Installer Anwendung, Zugangsdaten und systemd-Konfiguration auf den

--- a/hvv_display/web.py
+++ b/hvv_display/web.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import base64
 import binascii
+import errno
 import hashlib
 import html
 import json
@@ -103,7 +104,9 @@ def save_config(path: Path, raw_config: dict[str, Any]) -> None:
         except Exception:
             temporary.unlink(missing_ok=True)
             raise
-    except PermissionError:
+    except OSError as exc:
+        if exc.errno not in (errno.EACCES, errno.EROFS):
+            raise
         # The installed service owns config.json but not its root-owned parent
         # directory, so an atomic sibling replacement is not possible there.
         with path.open("w", encoding="utf-8") as handle:

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,4 +1,6 @@
 import base64
+import errno
+import json
 import os
 import stat
 import tempfile
@@ -14,6 +16,7 @@ from hvv_display.web import (
     hardware_status,
     hash_web_password,
     load_credentials,
+    save_config,
     save_credentials,
     verify_web_password,
 )
@@ -50,6 +53,22 @@ class WebApplicationTest(unittest.TestCase):
     def test_credentials_reject_environment_file_record_injection(self) -> None:
         with self.assertRaisesRegex(ValueError, "keine Zeilenumbrüche"):
             save_credentials(self.credentials, "application-id", "secret\nHTTPS_PROXY=http://attacker")
+
+    def test_config_save_falls_back_when_systemd_blocks_temporary_sibling(self) -> None:
+        raw_config = {
+            "api": {"base_url": "https://gti.geofox.de/gti/public/v1", "version": 63},
+            "display": {"rotate": 2},
+            "stations": [],
+        }
+        with patch(
+            "hvv_display.web.tempfile.NamedTemporaryFile",
+            side_effect=OSError(errno.EROFS, "Read-only file system"),
+        ):
+            save_config(self.config, raw_config)
+        self.assertEqual(
+            self.config.read_text(encoding="utf-8"),
+            json.dumps(raw_config, ensure_ascii=False, indent=2) + "\n",
+        )
 
     def test_settings_and_dashboard_include_csrf_tokens(self) -> None:
         settings = self.app.settings().decode("utf-8")


### PR DESCRIPTION
Behebt das Speichern von Web-Einstellungen unter ProtectSystem=strict. Der atomare temporäre Nachbar-Datei-Versuch kann mit EROFS scheitern; die Anwendung nutzt dann den bereits freigegebenen direkten Schreibpfad für config.json. Ergänzt einen Regressionstest und dokumentiert die Aktualisierung/Fehlerbehebung im README. Lokal geprüft: git diff --check und Bash-Syntax.