### PR TITLE
Implement #43: robustes Geofox-Haltestellenmanagement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 permissions:
@@ -39,6 +41,7 @@ jobs:
           python -m pip install --no-build-isolation --no-deps --editable .
 
       - name: Compile Python sources
+        if: matrix.python-version == '3.11'
         run: python -m compileall -q hvv_display tests
 
       - name: Run unit tests on compatibility versions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,15 +15,8 @@ concurrency:
 
 jobs:
   tests:
-    name: Python ${{ matrix.python-version }} tests and quality
+    name: Python 3.11 tests and quality
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-      matrix:
-        python-version:
-          - "3.10"
-          - "3.11"
-          - "3.13"
 
     steps:
       - name: Check out repository
@@ -32,7 +25,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
           cache: pip
 
       - name: Install project and test tools
@@ -41,33 +34,23 @@ jobs:
           python -m pip install --no-build-isolation --no-deps --editable .
 
       - name: Compile Python sources
-        if: matrix.python-version == '3.11'
         run: python -m compileall -q hvv_display tests
 
-      - name: Run unit tests on compatibility versions
-        if: matrix.python-version != '3.11'
-        run: python -m unittest discover -s tests -v
-
       - name: Run tests with coverage
-        if: matrix.python-version == '3.11'
         run: |
           coverage run -m unittest discover -s tests -v
           coverage report
 
       - name: Run Ruff
-        if: matrix.python-version == '3.11'
         run: ruff check .
 
       - name: Audit runtime dependencies
-        if: matrix.python-version == '3.11'
         run: pip-audit --requirement requirements.txt --disable-pip
 
       - name: Build package
-        if: matrix.python-version == '3.11'
         run: python -m build --no-isolation
 
       - name: Render display preview on primary version
-        if: matrix.python-version == '3.11'
         run: hvv-preview /tmp/hvv-anzeiger-preview.png
 
   shell:

--- a/hvv_display/geofox.py
+++ b/hvv_display/geofox.py
@@ -126,7 +126,9 @@ def _return_code_error(result: dict[str, Any]) -> GeofoxError:
         "FORCED_DEST_NOT_FOUND": "Zielstation wurde nicht eindeutig gefunden.",
     }
     if code == "ERROR_TEXT":
-        text = _safe_external_text(result.get("errorText") or "Geofox meldet einen Fehler")
+        text = _safe_external_text(
+            result.get("errorText") or "Geofox meldet einen Fehler"
+        )
         return GeofoxError(text, kind="validation", return_code=code)
     if code in user_messages:
         kind = "temporary" if code == "ERROR_COMM" else "validation"
@@ -393,7 +395,9 @@ class GeofoxClient:
             direction = str(line.get("direction", ""))
             response_station = raw.get("station") or {}
             response_station_id = (
-                response_station.get("id") if isinstance(response_station, dict) else None
+                response_station.get("id")
+                if isinstance(response_station, dict)
+                else None
             )
             selected_station = stations_by_id.get(response_station_id)
             if selected_station:
@@ -428,7 +432,9 @@ class GeofoxClient:
                     delay_seconds=delay_seconds,
                     cancelled=bool(raw.get("cancelled", False)),
                     station_label=(
-                        matching_stations[0].label if len(matching_stations) == 1 else ""
+                        matching_stations[0].label
+                        if len(matching_stations) == 1
+                        else ""
                     ),
                 )
             )

--- a/hvv_display/geofox.py
+++ b/hvv_display/geofox.py
@@ -35,9 +35,15 @@ class GeofoxError(RuntimeError):
         message: str,
         *,
         retry_after_seconds: int | None = None,
+        kind: str = "technical",
+        http_status: int | None = None,
+        return_code: str | None = None,
     ) -> None:
         super().__init__(message)
         self.retry_after_seconds = retry_after_seconds
+        self.kind = kind
+        self.http_status = http_status
+        self.return_code = return_code
 
 
 def _retry_after_seconds(value: Any, *, now: datetime | None = None) -> int | None:
@@ -103,13 +109,39 @@ def _https_base_url(value: str) -> str:
 
 
 def _safe_external_text(value: Any, limit: int = 160) -> str:
-    """Make API-controlled text safe for one-line logs and user messages."""
     return "".join(
         character if character.isprintable() else " " for character in str(value)
     ).strip()[:limit]
 
 
+def _return_code_error(result: dict[str, Any]) -> GeofoxError:
+    code = _safe_external_text(result.get("returnCode") or "UNKNOWN", 80)
+    user_messages = {
+        "ERROR_CN_TOO_MANY": "Zu viele Treffer – bitte genauer eingeben.",
+        "ERROR_COMM": "Geofox ist aktuell nicht erreichbar.",
+        "START_NOT_FOUND": "Haltestelle wurde nicht gefunden.",
+        "DEST_NOT_FOUND": "Zielstation wurde nicht gefunden.",
+        "VIA_NOT_FOUND": "Zwischenhaltestelle wurde nicht gefunden.",
+        "FORCED_START_NOT_FOUND": "Haltestelle wurde nicht eindeutig gefunden.",
+        "FORCED_DEST_NOT_FOUND": "Zielstation wurde nicht eindeutig gefunden.",
+    }
+    if code == "ERROR_TEXT":
+        text = _safe_external_text(result.get("errorText") or "Geofox meldet einen Fehler")
+        return GeofoxError(text, kind="validation", return_code=code)
+    if code in user_messages:
+        kind = "temporary" if code == "ERROR_COMM" else "validation"
+        return GeofoxError(user_messages[code], kind=kind, return_code=code)
+    return GeofoxError("Geofox meldet einen unbekannten Fehler.", return_code=code)
+
+
 class GeofoxClient:
+    # Geofox rate limits apply to the application, not to a Python object. The
+    # web UI creates clients for different operations, therefore all instances
+    # share one serialization lock and one request timestamp.
+    _global_rate_lock = threading.Lock()
+    _global_last_request_at = 0.0
+    _global_retry_until = 0.0
+
     def __init__(
         self,
         base_url: str,
@@ -122,7 +154,11 @@ class GeofoxClient:
         urlopen: Callable[..., Any] = urllib.request.urlopen,
     ) -> None:
         if not user or not password:
-            raise GeofoxError("GEOFOX_USER und GEOFOX_PASSWORD müssen gesetzt sein")
+            raise GeofoxError(
+                "GEOFOX_USER und GEOFOX_PASSWORD müssen gesetzt sein",
+                kind="credentials",
+                http_status=401,
+            )
         self.base_url = _https_base_url(base_url)
         self.user = user
         self._password = password.encode("utf-8")
@@ -130,32 +166,39 @@ class GeofoxClient:
         self.timeout = timeout
         self.min_request_interval = min_request_interval
         self._urlopen = urlopen
-        self._last_request_at = 0.0
-        self._rate_lock = threading.Lock()
 
     @staticmethod
     def encode_body(payload: dict[str, Any]) -> bytes:
-        return json.dumps(
-            payload, ensure_ascii=False, separators=(",", ":")
-        ).encode("utf-8")
+        return json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode(
+            "utf-8"
+        )
 
     def signature(self, body: bytes) -> str:
         digest = hmac.new(self._password, body, hashlib.sha1).digest()
         return base64.b64encode(digest).decode("ascii")
 
     def _wait_for_rate_limit(self) -> None:
-        with self._rate_lock:
-            remaining = self.min_request_interval - (
-                time.monotonic() - self._last_request_at
+        with self._global_rate_lock:
+            now = time.monotonic()
+            wait_until = max(
+                self._global_retry_until,
+                self._global_last_request_at + self.min_request_interval,
             )
+            remaining = wait_until - now
             if remaining > 0:
                 time.sleep(remaining)
-            self._last_request_at = time.monotonic()
+            type(self)._global_last_request_at = time.monotonic()
+
+    @classmethod
+    def _apply_retry_after(cls, seconds: int | None) -> None:
+        if seconds:
+            cls._global_retry_until = max(
+                cls._global_retry_until, time.monotonic() + seconds
+            )
 
     def _post(self, method: str, payload: dict[str, Any]) -> dict[str, Any]:
         body = self.encode_body(payload)
         trace_id = str(uuid.uuid4())
-        # The base URL is validated as HTTPS before urllib receives it.
         request = urllib.request.Request(  # noqa: S310
             f"{self.base_url}/{method}",
             data=body,
@@ -177,19 +220,35 @@ class GeofoxClient:
                 raw = response.read(MAX_RESPONSE_BYTES + 1)
         except urllib.error.HTTPError as exc:
             LOG.error("Geofox HTTP %s, Trace-ID %s", exc.code, trace_id)
-            if exc.code == 401:
-                raise GeofoxError("Geofox-Zugangsdaten wurden abgelehnt") from exc
+            retry_after = _retry_after_seconds(exc.headers.get("Retry-After"))
             if exc.code == 429:
+                self._apply_retry_after(retry_after)
                 raise GeofoxError(
-                    "Geofox-Anfragelimit erreicht",
-                    retry_after_seconds=_retry_after_seconds(
-                        exc.headers.get("Retry-After")
-                    ),
+                    "Geofox-Anfragelimit erreicht – bitte später erneut versuchen.",
+                    retry_after_seconds=retry_after,
+                    kind="rate_limit",
+                    http_status=429,
                 ) from exc
-            raise GeofoxError(f"Geofox antwortet mit HTTP {exc.code}") from exc
+            if exc.code in (401, 403):
+                raise GeofoxError(
+                    "Geofox-Zugangsdaten oder Berechtigungen wurden abgelehnt.",
+                    kind="credentials",
+                    http_status=exc.code,
+                ) from exc
+            if exc.code in (500, 503):
+                raise GeofoxError(
+                    "Geofox ist aktuell nicht erreichbar.",
+                    kind="temporary",
+                    http_status=exc.code,
+                ) from exc
+            raise GeofoxError(
+                f"Geofox antwortet mit HTTP {exc.code}", http_status=exc.code
+            ) from exc
         except (urllib.error.URLError, TimeoutError, OSError) as exc:
             LOG.error("Geofox nicht erreichbar, Trace-ID %s", trace_id)
-            raise GeofoxError("Geofox ist nicht erreichbar") from exc
+            raise GeofoxError(
+                "Geofox ist aktuell nicht erreichbar.", kind="temporary"
+            ) from exc
 
         if len(raw) > MAX_RESPONSE_BYTES:
             LOG.error("Geofox-Antwort zu groß, Trace-ID %s", trace_id)
@@ -208,21 +267,20 @@ class GeofoxClient:
                 _safe_external_text(result.get("returnCode"), 80),
                 trace_id,
             )
-            message = _safe_external_text(
-                result.get("errorText") or result.get("returnCode") or "Unbekannt"
-            )
-            raise GeofoxError(f"Geofox-Fehler: {message}")
+            raise _return_code_error(result)
         return result
 
-    def find_station(self, name: str, city: str = "Hamburg") -> dict[str, str]:
+    def find_station(self, name: str, city: str = "Hamburg") -> dict[str, Any]:
         matches = self.find_stations(name, city)
         if not matches:
-            raise GeofoxError(f"Haltestelle {city}, {name} wurde nicht gefunden")
+            raise GeofoxError(
+                f"Haltestelle {city}, {name} wurde nicht gefunden", kind="validation"
+            )
         if len(matches) > 1:
             names = ", ".join(str(item.get("combinedName")) for item in matches[:3])
             raise GeofoxError(
-                f"Haltestelle {name} ist nicht eindeutig ({names}); "
-                "ID in config.json setzen"
+                f"Haltestelle {name} ist nicht eindeutig ({names}); bitte auswählen.",
+                kind="validation",
             )
         station = matches[0]
         return {
@@ -230,9 +288,10 @@ class GeofoxClient:
             "city": str(station.get("city") or city),
             "id": str(station["id"]),
             "type": "STATION",
+            "serviceTypes": list(station.get("serviceTypes") or []),
         }
 
-    def find_stations(self, name: str, city: str = "Hamburg") -> list[dict[str, str]]:
+    def find_stations(self, name: str, city: str = "Hamburg") -> list[dict[str, Any]]:
         result = self._post(
             "checkName",
             {
@@ -243,10 +302,15 @@ class GeofoxClient:
                 "coordinateType": "EPSG_4326",
             },
         )
+        raw_results = result.get("results") or []
+        if not isinstance(raw_results, list):
+            raise GeofoxError("Geofox liefert keine gültige Haltestellenliste")
         candidates = [
             candidate
-            for candidate in (result.get("results") or [])
-            if candidate.get("type") == "STATION" and candidate.get("id")
+            for candidate in raw_results
+            if isinstance(candidate, dict)
+            and candidate.get("type") == "STATION"
+            and candidate.get("id")
         ]
         target_name = normalize(name)
         target_city = normalize(city)
@@ -266,14 +330,19 @@ class GeofoxClient:
         ]
         return [
             {
-                "name": str(station.get("name") or name),
-                "city": str(station.get("city") or city),
-                "id": str(station["id"]),
-                "combinedName": str(
-                    station.get("combinedName") or station.get("name") or name
+                "name": _safe_external_text(station.get("name") or name, 120),
+                "city": _safe_external_text(station.get("city") or city, 80),
+                "id": _safe_external_text(station["id"], 160),
+                "combinedName": _safe_external_text(
+                    station.get("combinedName") or station.get("name") or name, 200
                 ),
+                "serviceTypes": [
+                    _safe_external_text(item, 40)
+                    for item in (station.get("serviceTypes") or [])
+                    if isinstance(item, (str, int))
+                ][:20],
             }
-            for station in matches
+            for station in matches[:10]
         ]
 
     def departure_list(
@@ -306,9 +375,7 @@ class GeofoxClient:
 
         result = self._post("departureList", payload)
         stations_by_id = {
-            station.station_id: station
-            for station in stations
-            if station.station_id
+            station.station_id: station for station in stations if station.station_id
         }
         departures: list[Departure] = []
         raw_departures = result.get("departures") or []
@@ -326,9 +393,7 @@ class GeofoxClient:
             direction = str(line.get("direction", ""))
             response_station = raw.get("station") or {}
             response_station_id = (
-                response_station.get("id")
-                if isinstance(response_station, dict)
-                else None
+                response_station.get("id") if isinstance(response_station, dict) else None
             )
             selected_station = stations_by_id.get(response_station_id)
             if selected_station:
@@ -363,9 +428,7 @@ class GeofoxClient:
                     delay_seconds=delay_seconds,
                     cancelled=bool(raw.get("cancelled", False)),
                     station_label=(
-                        matching_stations[0].label
-                        if len(matching_stations) == 1
-                        else ""
+                        matching_stations[0].label if len(matching_stations) == 1 else ""
                     ),
                 )
             )

--- a/hvv_display/web.py
+++ b/hvv_display/web.py
@@ -31,6 +31,10 @@ LOG = logging.getLogger(__name__)
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8080
 PASSWORD_HASH_ITERATIONS = 600_000
+MAX_FORM_BYTES = 1_000_000
+MAX_QUERY_LENGTH = 120
+MAX_CITY_LENGTH = 80
+MAX_STATION_ID_LENGTH = 160
 
 
 def hash_web_password(password: str) -> str:
@@ -90,11 +94,7 @@ def save_config(path: Path, raw_config: dict[str, Any]) -> None:
     mode = path.stat().st_mode & 0o777 if path.exists() else 0o600
     try:
         with tempfile.NamedTemporaryFile(
-            mode="w",
-            encoding="utf-8",
-            dir=path.parent,
-            prefix=f".{path.name}.",
-            delete=False,
+            mode="w", encoding="utf-8", dir=path.parent, prefix=f".{path.name}.", delete=False
         ) as handle:
             handle.write(payload)
             temporary = Path(handle.name)
@@ -107,8 +107,6 @@ def save_config(path: Path, raw_config: dict[str, Any]) -> None:
     except OSError as exc:
         if exc.errno not in (errno.EACCES, errno.EROFS):
             raise
-        # The installed service owns config.json but not its root-owned parent
-        # directory, so an atomic sibling replacement is not possible there.
         with path.open("w", encoding="utf-8") as handle:
             handle.write(payload)
             handle.flush()
@@ -117,8 +115,7 @@ def save_config(path: Path, raw_config: dict[str, Any]) -> None:
 
 
 def _minutes_until(departure: Any, now: datetime) -> int:
-    seconds = (departure.departure_time - now).total_seconds()
-    return max(0, round(seconds / 60))
+    return max(0, round((departure.departure_time - now).total_seconds() / 60))
 
 
 def _departure_payload(departures: list[Any], now: datetime) -> list[dict[str, Any]]:
@@ -137,7 +134,6 @@ def _departure_payload(departures: list[Any], now: datetime) -> list[dict[str, A
 
 
 def hardware_status() -> dict[str, str]:
-    """Return safe, human-readable local resource information."""
     cpu_count = os.cpu_count() or 1
     try:
         load = os.getloadavg()[0]
@@ -164,49 +160,19 @@ def hardware_status() -> dict[str, str]:
 
 
 def _page(title: str, content: str) -> bytes:
-    return f"""<!doctype html>
-<html lang="de"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<title>{html.escape(title)} · HVV-Anzeiger</title>
-<style>
-:root {{ color-scheme: dark; font-family: system-ui, sans-serif; background:#0b1220; color:#f4f7fb; }}
-body {{ margin:0; background:linear-gradient(135deg,#0b1220,#17233b); min-height:100vh; }}
-main {{ max-width:980px; margin:auto; padding:24px 16px 48px; }}
-a {{ color:#8bd3ff; }} h1 {{ margin:0 0 8px; font-size:clamp(2rem,6vw,4rem); }}
-.subtle {{ color:#aab8cb; }} .toolbar {{ display:flex; justify-content:space-between; gap:16px; align-items:center; flex-wrap:wrap; margin:20px 0; }}
-.board {{ background:#05080e; border:1px solid #324057; border-radius:18px; overflow:hidden; box-shadow:0 18px 50px #0006; }}
-.row {{ display:grid; grid-template-columns:76px 1fr 100px; gap:16px; align-items:center; padding:18px 22px; border-bottom:1px solid #202a3b; }}
-.row:last-child {{ border:0; }} .line {{ color:#ffd447; font-size:2rem; font-weight:800; }} .destination {{ font-size:1.2rem; }}
-.time {{ text-align:right; font-size:1.8rem; font-variant-numeric:tabular-nums; }} .station {{ color:#8bd3ff; font-size:.8rem; }}
-.delay {{ color:#ff9d66; font-size:.85rem; }} .cancelled {{ color:#ff6b7a; text-decoration:line-through; }}
-.status {{ display:grid; grid-template-columns:repeat(3,1fr); gap:10px; margin:16px 0; }} .status div {{ background:#121c2d; border:1px solid #324057; border-radius:12px; padding:14px; }} .status strong {{ display:block; font-size:1.15rem; margin-top:4px; }}
-.setting {{ min-width:0; }} .control-row {{ display:flex; gap:8px; align-items:center; }} .control-row input, .control-row select {{ flex:1; min-width:0; }} .reset {{ background:#26344a; border-color:#53627a; font-size:.85rem; }}
-.station-card {{ border:1px solid #53627a; border-radius:12px; padding:16px; margin:14px 0; }} .station-heading {{ display:flex; justify-content:space-between; align-items:center; gap:12px; }} .station-heading h2, .station-heading h3 {{ margin-top:0; }} .route-row {{ display:grid; grid-template-columns:1fr 2fr auto; gap:8px; margin:8px 0; }}
-.station-search {{ display:flex; gap:8px; align-items:center; flex-wrap:wrap; margin-top:14px; }} .station-search select {{ min-width:280px; flex:1; }}
-button, input, textarea {{ font:inherit; border-radius:9px; border:1px solid #53627a; padding:10px 12px; background:#101a2b; color:inherit; }}
-button {{ cursor:pointer; background:#207bb3; border-color:#65c6ff; font-weight:700; }} textarea {{ width:100%; min-height:420px; box-sizing:border-box; font-family:ui-monospace,monospace; font-size:.9rem; }}
-label {{ display:block; margin:14px 0 6px; font-weight:700; }} .card {{ background:#121c2d; border:1px solid #324057; border-radius:14px; padding:20px; margin-top:18px; }}
-.explanations {{ margin:0; padding-left:20px; line-height:1.6; }} .danger {{ background:#7e2632; border-color:#ff8793; margin-left:8px; }}
-.notice {{ padding:14px 16px; border-radius:10px; background:#3b2913; color:#ffdca6; margin:16px 0; }} .empty {{ padding:42px 22px; text-align:center; color:#aab8cb; }}
+    return f"""<!doctype html><html lang="de"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>{html.escape(title)} · HVV-Anzeiger</title><style>
+:root{{color-scheme:dark;font-family:system-ui,sans-serif;background:#0b1220;color:#f4f7fb}}body{{margin:0;background:linear-gradient(135deg,#0b1220,#17233b);min-height:100vh}}main{{max-width:980px;margin:auto;padding:24px 16px 48px}}a{{color:#8bd3ff}}h1{{margin:0 0 8px;font-size:clamp(2rem,6vw,4rem)}}.subtle{{color:#aab8cb}}.toolbar{{display:flex;justify-content:space-between;gap:16px;align-items:center;flex-wrap:wrap;margin:20px 0}}.board{{background:#05080e;border:1px solid #324057;border-radius:18px;overflow:hidden;box-shadow:0 18px 50px #0006}}.row{{display:grid;grid-template-columns:76px 1fr 100px;gap:16px;align-items:center;padding:18px 22px;border-bottom:1px solid #202a3b}}.row:last-child{{border:0}}.line{{color:#ffd447;font-size:2rem;font-weight:800}}.destination{{font-size:1.2rem}}.time{{text-align:right;font-size:1.8rem;font-variant-numeric:tabular-nums}}.station{{color:#8bd3ff;font-size:.8rem}}.delay{{color:#ff9d66;font-size:.85rem}}.cancelled{{color:#ff6b7a;text-decoration:line-through}}.status,.grid{{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:10px;margin:16px 0}}.status div,.card{{background:#121c2d;border:1px solid #324057;border-radius:14px;padding:20px}}.status strong{{display:block;font-size:1.15rem;margin-top:4px}}.setting{{min-width:0}}.control-row,.station-search{{display:flex;gap:8px;align-items:center;flex-wrap:wrap}}.control-row input,.control-row select{{flex:1;min-width:0}}.reset{{background:#26344a;border-color:#53627a;font-size:.85rem}}.station-card{{border:1px solid #53627a;border-radius:12px;padding:16px;margin:14px 0}}.station-heading{{display:flex;justify-content:space-between;align-items:center;gap:12px}}.route-row{{display:grid;grid-template-columns:1fr 2fr auto;gap:8px;margin:8px 0}}.station-search{{margin-top:10px}}.station-search select{{min-width:280px;flex:1}}button,input,textarea,select{{font:inherit;border-radius:9px;border:1px solid #53627a;padding:10px 12px;background:#101a2b;color:inherit}}button{{cursor:pointer;background:#207bb3;border-color:#65c6ff;font-weight:700}}button:disabled{{opacity:.55;cursor:wait}}label{{display:block;margin:14px 0 6px;font-weight:700}}.card{{margin-top:18px}}.danger{{background:#7e2632;border-color:#ff8793;margin-left:8px}}.notice{{padding:14px 16px;border-radius:10px;background:#3b2913;color:#ffdca6;margin:16px 0}}.ok{{color:#8ee6ad}}.error{{color:#ff9aa5}}.empty{{padding:42px 22px;text-align:center;color:#aab8cb}}.spinner{{display:inline-block;width:14px;height:14px;border:2px solid #53627a;border-top-color:#8bd3ff;border-radius:50%;animation:spin .8s linear infinite;vertical-align:-2px}}@keyframes spin{{to{{transform:rotate(360deg)}}}}details.help-box{{margin-top:12px}}code{{overflow-wrap:anywhere}}
 </style></head><body><main>{content}</main></body></html>""".encode()
 
 
 class WebApplication:
-    def __init__(
-        self,
-        config_path: Path,
-        credentials_path: Path,
-        cache_path: Path,
-        *,
-        access_token: str | None = None,
-        web_env_path: Path | None = None,
-    ) -> None:
+    def __init__(self, config_path: Path, credentials_path: Path, cache_path: Path, *, access_token: str | None = None, web_env_path: Path | None = None) -> None:
         self.config_path = config_path
         self.credentials_path = credentials_path
         self.cache_path = cache_path
         self.access_token = access_token
-        self.web_env_path = web_env_path or Path(
-            os.environ.get("HVV_WEB_ENV_FILE", "var/web.env")
-        )
+        self.web_env_path = web_env_path or Path(os.environ.get("HVV_WEB_ENV_FILE", "var/web.env"))
         self.csrf_token = secrets.token_urlsafe(32)
 
     def authorize(self, headers: Any) -> bool:
@@ -220,30 +186,22 @@ class WebApplication:
         except (binascii.Error, UnicodeDecodeError):
             return False
         username, separator, password = decoded.partition(":")
-        return separator == ":" and username == "hvv-anzeiger" and verify_web_password(
-            password, self.access_token
-        )
+        return separator == ":" and username == "hvv-anzeiger" and verify_web_password(password, self.access_token)
 
     def validate_csrf(self, token: str) -> None:
         if not secrets.compare_digest(token, self.csrf_token):
             raise PermissionError("Ungültige Sitzungsbestätigung")
 
     def save_web_password(self, password: str) -> None:
-        if not password or any(
-            character in password for character in ("\r", "\n", "\x00", '"', "\\")
-        ):
-            raise ValueError(
-                "Das Webpasswort darf nicht leer sein oder Sonderzeichen für die Env-Datei enthalten"
-            )
+        if not password or any(character in password for character in ("\r", "\n", "\x00", '"', "\\")):
+            raise ValueError("Das Webpasswort darf nicht leer sein oder Sonderzeichen für die Env-Datei enthalten")
         self.web_env_path.parent.mkdir(parents=True, exist_ok=True)
         temporary = self.web_env_path.with_name(f".{self.web_env_path.name}.tmp")
-        temporary.write_text(
-            f'HVV_WEB_PASSWORD_HASH="{hash_web_password(password)}"\n',
-            encoding="utf-8",
-        )
+        encoded = hash_web_password(password)
+        temporary.write_text(f'HVV_WEB_PASSWORD_HASH="{encoded}"\n', encoding="utf-8")
         os.chmod(temporary, 0o600)
         os.replace(temporary, self.web_env_path)
-        self.access_token = hash_web_password(password)
+        self.access_token = encoded
 
     def raw_config(self) -> dict[str, Any]:
         raw = json.loads(self.config_path.read_text(encoding="utf-8"))
@@ -253,49 +211,62 @@ class WebApplication:
 
     @staticmethod
     def restart_system() -> None:
-        result = subprocess.run(
-            ["/usr/bin/sudo", "-n", "systemctl", "reboot"],
-            check=False,
-            capture_output=True,
-            text=True,
-        )
+        result = subprocess.run(["/usr/bin/sudo", "-n", "systemctl", "reboot"], check=False, capture_output=True, text=True)
         if result.returncode:
             raise OSError("Systemneustart wurde abgelehnt; systemctl-Berechtigung prüfen")
+
+    def _client(self, *, user: str | None = None, password: str | None = None) -> GeofoxClient:
+        config = load_config(self.config_path)
+        credentials = load_credentials(self.credentials_path)
+        return GeofoxClient(
+            config.api.base_url,
+            user if user is not None else credentials.get("GEOFOX_USER", ""),
+            password if password is not None else credentials.get("GEOFOX_PASSWORD", ""),
+            version=config.api.version,
+            timeout=config.api.request_timeout_seconds,
+        )
 
     def departures(self) -> tuple[list[dict[str, Any]], str | None]:
         now = datetime.now(HAMBURG_TZ).replace(second=0, microsecond=0)
         config = load_config(self.config_path)
-        credentials = load_credentials(self.credentials_path)
-        client = GeofoxClient(
-            config.api.base_url,
-            credentials.get("GEOFOX_USER", ""),
-            credentials.get("GEOFOX_PASSWORD", ""),
-            version=config.api.version,
-            timeout=config.api.request_timeout_seconds,
-        )
+        client = self._client()
         stations = resolve_stations(client, config.stations, self.cache_path)
-        departures = client.departure_list(
-            stations,
-            now=now,
-            max_list=30,
-            max_time_offset=config.api.max_time_offset_minutes,
-        )
+        departures = client.departure_list(stations, now=now, max_list=30, max_time_offset=config.api.max_time_offset_minutes)
         return _departure_payload(departures[: config.api.max_departures], now), None
 
-    def station_suggestions(self, query: str, city: str) -> list[dict[str, str]]:
+    def station_suggestions(self, query: str, city: str) -> list[dict[str, Any]]:
         query = query.strip()
+        city = city.strip() or "Hamburg"
         if len(query) < 2:
             raise ValueError("Bitte mindestens zwei Zeichen eingeben")
-        config = load_config(self.config_path)
-        credentials = load_credentials(self.credentials_path)
-        client = GeofoxClient(
-            config.api.base_url,
-            credentials.get("GEOFOX_USER", ""),
-            credentials.get("GEOFOX_PASSWORD", ""),
-            version=config.api.version,
-            timeout=config.api.request_timeout_seconds,
-        )
-        return client.find_stations(query, city.strip() or "Hamburg")
+        if len(query) > MAX_QUERY_LENGTH or len(city) > MAX_CITY_LENGTH:
+            raise ValueError("Suchbegriff oder Stadt ist zu lang")
+        return self._client().find_stations(query, city)
+
+    def validate_station_config(self, raw_config: dict[str, Any], *, user: str, password: str) -> dict[str, Any]:
+        stations = raw_config.get("stations")
+        if not isinstance(stations, list) or not stations:
+            raise ValueError("Mindestens eine Haltestelle muss konfiguriert sein")
+        client = self._client(user=user, password=password)
+        for index, station in enumerate(stations):
+            if not isinstance(station, dict):
+                raise ValueError(f"Haltestelle {index + 1} ist ungültig")
+            name = str(station.get("name") or "").strip()
+            city = str(station.get("city") or "Hamburg").strip()
+            station_id = str(station.get("id") or "").strip()
+            if not name or not station_id:
+                raise ValueError(f"Haltestelle {index + 1}: Bitte einen Geofox-Vorschlag auswählen")
+            if len(name) > MAX_QUERY_LENGTH or len(city) > MAX_CITY_LENGTH or len(station_id) > MAX_STATION_ID_LENGTH:
+                raise ValueError(f"Haltestelle {index + 1}: Eingabe ist zu lang")
+            matches = client.find_stations(name, city)
+            match = next((item for item in matches if item.get("id") == station_id), None)
+            if match is None:
+                raise ValueError(f"Haltestelle {index + 1}: Geofox findet die ausgewählte Haltestelle nicht mehr")
+            station["name"] = match["name"]
+            station["city"] = match["city"]
+            station["id"] = match["id"]
+            station["serviceTypes"] = match.get("serviceTypes", [])
+        return raw_config
 
     def dashboard(self) -> bytes:
         try:
@@ -303,139 +274,80 @@ class WebApplication:
         except (ConfigError, GeofoxError, OSError) as exc:
             departures, error = [], str(exc)
         rows = "".join(
-            f'<div class="row"><div><div class="line">{html.escape(item["line"])}</div>'
-            f'<div class="station">{html.escape(item["station"])}</div></div>'
-            f'<div class="destination">{html.escape(item["destination"])}'
-            f'{" <span class=delay>(+" + str(item["delay_seconds"] // 60) + " min)</span>" if item["delay_seconds"] else ""}</div>'
-            f'<div class="time {"cancelled" if item["cancelled"] else ""}">{item["time"]}<br><small>in {item["minutes"]} min</small></div></div>'
+            f'<div class="row"><div><div class="line">{html.escape(item["line"])}</div><div class="station">{html.escape(item["station"])}</div></div><div class="destination">{html.escape(item["destination"])}{(" <span class=delay>(+" + str(item["delay_seconds"] // 60) + " min)</span>") if item["delay_seconds"] else ""}</div><div class="time {"cancelled" if item["cancelled"] else ""}">{item["time"]}<br><small>in {item["minutes"]} min</small></div></div>'
             for item in departures
-        )
-        if not rows:
-            rows = '<div class="empty">Keine passende Abfahrt verfügbar.</div>'
+        ) or '<div class="empty">Keine passende Abfahrt verfügbar.</div>'
         message = f'<div class="notice">{html.escape(error)}</div>' if error else ""
         status = hardware_status()
-        content = f"""<div class="toolbar"><div><h1>Abfahrten</h1><div class="subtle">Lokale HVV-Anzeige · aktualisiert beim Öffnen</div></div>
-<div><a href="/settings">Einstellungen</a> · <a href="/">Aktualisieren</a></div></div>{message}<section class="board" aria-label="Abfahrtsanzeige">{rows}</section>
-<section class="status" aria-label="Hardware-Status"><div>CPU<strong>{html.escape(status["cpu"])}</strong></div><div>RAM<strong>{html.escape(status["ram"])}</strong></div><div>SD-Speicher<strong>{html.escape(status["storage"])}</strong></div></section>
-<form method="post" action="/system/restart" onsubmit="return confirm('Raspberry Pi wirklich neu starten?');"><input type="hidden" name="csrf_token" value="{html.escape(self.csrf_token, quote=True)}"><button class="danger" type="submit">System neu starten</button></form>"""
+        content = f'''<div class="toolbar"><div><h1>Abfahrten</h1><div class="subtle">Lokale HVV-Anzeige · aktualisiert beim Öffnen</div></div><div><a href="/settings">Einstellungen</a> · <a href="/">Aktualisieren</a></div></div>{message}<section class="board" aria-label="Abfahrtsanzeige">{rows}</section><section class="status" aria-label="Hardware-Status"><div>CPU<strong>{html.escape(status["cpu"])}</strong></div><div>RAM<strong>{html.escape(status["ram"])}</strong></div><div>SD-Speicher<strong>{html.escape(status["storage"])}</strong></div></section><form method="post" action="/system/restart" onsubmit="return confirm('Raspberry Pi wirklich neu starten?');"><input type="hidden" name="csrf_token" value="{html.escape(self.csrf_token, quote=True)}"><button class="danger" type="submit">System neu starten</button></form>'''
         return _page("Abfahrten", content)
 
     def settings(self, message: str = "", restart_required: bool = False) -> bytes:
         raw_config = self.raw_config()
         credentials = load_credentials(self.credentials_path)
         notice = f'<div class="notice">{html.escape(message)}</div>' if message else ""
-        restart_notice = ""
-        if restart_required:
-            restart_notice = f'''<div class="notice">Diese Änderung wird erst nach einem Neustart vollständig aktiv. Jetzt neu starten?<form method="post" action="/system/restart"><input type="hidden" name="csrf_token" value="{html.escape(self.csrf_token, quote=True)}"><button class="danger" type="submit">Jetzt neu starten</button></form></div>'''
-        defaults = {
-            "api.base_url": "https://gti.geofox.de/gti/public",
-            "api.version": 63,
-            "api.refresh_seconds": 15,
-            "api.request_timeout_seconds": 8,
-            "api.max_departures": 5,
-            "api.max_time_offset_minutes": 90,
-            "api.max_stale_age_minutes": 5,
-            "display.spi_port": 0,
-            "display.spi_device": 0,
-            "display.gpio_dc": 24,
-            "display.gpio_reset": 25,
-            "display.rotate": 0,
-            "display.bus_speed_hz": 16_000_000,
-            "display.bgr": False,
-            "night_shutdown.enabled": False,
-            "night_shutdown.start": "21:00",
-            "night_shutdown.end": "06:30",
-        }
-        descriptions = {
-            "api.base_url": "Offizielle HTTPS-Adresse der Geofox-Schnittstelle.",
-            "api.version": "API-Version des Geofox-Vertrags.",
-            "api.refresh_seconds": "Sekunden zwischen Abfragen; mindestens 15.",
-            "api.request_timeout_seconds": "Maximale Wartezeit pro Anfrage.",
-            "api.max_departures": "Sichtbare Abfahrten; 1 bis 5.",
-            "api.max_time_offset_minutes": "Wie weit in die Zukunft gesucht wird.",
-            "api.max_stale_age_minutes": "Wie lange alte Daten sichtbar bleiben.",
-            "display.spi_port": "Nummer des SPI-Busses.",
-            "display.spi_device": "Chip-Select des Displays.",
-            "display.gpio_dc": "GPIO für Data/Command.",
-            "display.gpio_reset": "GPIO für Display-Reset.",
-            "display.rotate": "Drehung: 0 bis 3 Vierteldrehungen.",
-            "display.bus_speed_hz": "SPI-Takt in Hertz.",
-            "display.bgr": "Bei vertauschten Rot-/Blaukanälen aktivieren.",
-            "night_shutdown.enabled": "Pausiert nachts Abfragen und Display.",
-            "night_shutdown.start": "Beginn in Hamburger Ortszeit (HH:MM).",
-            "night_shutdown.end": "Ende in Hamburger Ortszeit (HH:MM).",
-        }
-
-        def current(path: str) -> Any:
-            section, key = path.split(".")
-            return raw_config.get(section, {}).get(key, defaults[path])
+        defaults = {"api.base_url":"https://gti.geofox.de/gti/public","api.version":63,"api.refresh_seconds":15,"api.request_timeout_seconds":8,"api.max_departures":5,"api.max_time_offset_minutes":90,"api.max_stale_age_minutes":5,"display.spi_port":0,"display.spi_device":0,"display.gpio_dc":24,"display.gpio_reset":25,"display.rotate":0,"display.bus_speed_hz":16000000,"display.bgr":False,"night_shutdown.enabled":False,"night_shutdown.start":"21:00","night_shutdown.end":"06:30"}
+        descriptions = {"api.base_url":"Offizielle HTTPS-Adresse der Geofox-Schnittstelle.","api.version":"API-Version des Geofox-Vertrags.","api.refresh_seconds":"Sekunden zwischen Abfragen; mindestens 15.","api.request_timeout_seconds":"Maximale Wartezeit pro Anfrage.","api.max_departures":"Sichtbare Abfahrten; 1 bis 5.","api.max_time_offset_minutes":"Wie weit in die Zukunft gesucht wird.","api.max_stale_age_minutes":"Wie lange alte Daten sichtbar bleiben.","display.spi_port":"Nummer des SPI-Busses.","display.spi_device":"Chip-Select des Displays.","display.gpio_dc":"GPIO für Data/Command.","display.gpio_reset":"GPIO für Display-Reset.","display.rotate":"Drehung: 0 bis 3 Vierteldrehungen.","display.bus_speed_hz":"SPI-Takt in Hertz.","display.bgr":"Bei vertauschten Rot-/Blaukanälen aktivieren.","night_shutdown.enabled":"Pausiert nachts Abfragen und Display.","night_shutdown.start":"Beginn in Hamburger Ortszeit (HH:MM).","night_shutdown.end":"Ende in Hamburger Ortszeit (HH:MM)."}
 
         def scalar(path: str, input_type: str = "text") -> str:
-            value = current(path)
+            section, key = path.split(".")
+            value = raw_config.get(section, {}).get(key, defaults[path])
             default = defaults[path]
             if isinstance(default, bool):
-                control = (
-                    f'<select id="{path}" data-path="{path}" data-type="bool" '
-                    f'data-default="{str(default).lower()}">'
-                    f'<option value="false" {"selected" if not value else ""}>Nein</option>'
-                    f'<option value="true" {"selected" if value else ""}>Ja</option></select>'
-                )
+                control = f'<select id="{path}" data-path="{path}" data-type="bool" data-default="{str(default).lower()}"><option value="false" {"selected" if not value else ""}>Nein</option><option value="true" {"selected" if value else ""}>Ja</option></select>'
             else:
-                control = (
-                    f'<input id="{path}" data-path="{path}" type="{input_type}" '
-                    f'value="{html.escape(str(value), quote=True)}" '
-                    f'data-default="{html.escape(str(default), quote=True)}">'
-                )
-            return (
-                f'<div class="setting"><label for="{path}">{path}</label>'
-                f'<div class="control-row">{control}'
-                f'<button type="button" class="reset" onclick="resetField(this)">Auf Standard zurücksetzen</button></div>'
-                f'<div class="subtle help">{descriptions[path]}</div></div>'
-            )
+                control = f'<input id="{path}" data-path="{path}" type="{input_type}" value="{html.escape(str(value), quote=True)}" data-default="{html.escape(str(default), quote=True)}">'
+            return f'<div class="setting"><label for="{path}">{path}</label><div class="control-row">{control}<button type="button" class="reset" onclick="resetField(this)">Auf Standard zurücksetzen</button></div><div class="subtle">{descriptions[path]}</div></div>'
 
         def station_card(station: dict[str, Any], index: int) -> str:
             routes = "".join(
-                f'<div class="route-row"><input data-route="line" value="{html.escape(str(route.get("line", "")), quote=True)}" placeholder="Linie" aria-label="Linie">'
-                f'<input data-route="destination" value="{html.escape(str(route.get("destination", "")), quote=True)}" placeholder="Ziel" aria-label="Ziel">'
-                '<button type="button" class="reset" onclick="this.parentElement.remove()">Route entfernen</button></div>'
+                f'<div class="route-row"><input data-route="line" value="{html.escape(str(route.get("line", "")), quote=True)}" placeholder="Linie" aria-label="Linie"><input data-route="destination" value="{html.escape(str(route.get("destination", "")), quote=True)}" placeholder="Ziel" aria-label="Ziel"><button type="button" class="reset" onclick="this.parentElement.remove()">Route entfernen</button></div>'
                 for route in station.get("routes", [])
             )
-            return f'''<article class="station-card" data-station>
+            valid = bool(station.get("id"))
+            service_types = json.dumps(station.get("serviceTypes", []), ensure_ascii=False)
+            return f'''<article class="station-card" data-station data-valid="{str(valid).lower()}">
 <div class="station-heading"><h3>Haltestelle {index + 1}</h3><button type="button" class="reset" onclick="this.closest('[data-station]').remove()">Haltestelle entfernen</button></div>
-<div class="grid"><div><label>Name</label><input data-station-field="name" value="{html.escape(str(station.get("name", "")), quote=True)}" required><div class="subtle help">Offizieller Haltestellenname.</div></div>
-<div><label>Stadt</label><input data-station-field="city" value="{html.escape(str(station.get("city", "Hamburg")), quote=True)}" required><div class="subtle help">Stadt für die Geofox-Suche.</div></div>
-<div><label>Geofox-ID (optional)</label><input data-station-field="id" value="{html.escape(str(station.get("id") or ""), quote=True)}"><div class="subtle help">Nur eintragen, wenn sicher bekannt; sonst leer lassen.</div></div>
-<div><label>Kürzel</label><input data-station-field="label" maxlength="3" value="{html.escape(str(station.get("label", "")), quote=True)}" required><div class="subtle help">1–3 Zeichen für die Anzeige.</div></div></div>
-<div class="station-search"><button type="button" onclick="searchStation(this)">Geofox-Suche</button><select data-station-results onchange="applyStation(this)"><option value="">Treffer auswählen …</option></select><span class="subtle" data-search-message></span></div>
+<div class="grid"><div><label>Name</label><input data-station-field="name" maxlength="{MAX_QUERY_LENGTH}" value="{html.escape(str(station.get("name", "")), quote=True)}" required autocomplete="off"><div class="subtle">Mindestens 2 Zeichen. Vorschläge erscheinen automatisch.</div></div><div><label>Stadt</label><input data-station-field="city" maxlength="{MAX_CITY_LENGTH}" value="{html.escape(str(station.get("city", "Hamburg")), quote=True)}" required><div class="subtle">Wird nach Auswahl aus Geofox übernommen.</div></div><div><label>Geofox-ID</label><input data-station-field="id" maxlength="{MAX_STATION_ID_LENGTH}" value="{html.escape(str(station.get("id") or ""), quote=True)}" readonly tabindex="-1"><div class="subtle">Technisches Metadatum; wird automatisch gesetzt.</div></div><div><label>Kürzel</label><input data-station-field="label" maxlength="3" value="{html.escape(str(station.get("label", "")), quote=True)}" required><div class="subtle">1–3 Zeichen für die Anzeige.</div></div></div>
+<input type="hidden" data-station-field="serviceTypes" value="{html.escape(service_types, quote=True)}">
+<div class="station-search"><select data-station-results aria-label="Geofox-Haltestellenvorschläge"><option value="">Treffer auswählen …</option></select><span class="subtle" data-search-message>{'<span class="ok">✓ Geofox-Haltestelle ausgewählt</span>' if valid else 'Bitte Haltestelle aus einem Geofox-Vorschlag auswählen.'}</span></div>
+<details class="help-box"><summary>Richtung oder Zielstation?</summary><p><strong>Richtung</strong> wählt später den Linienast; auch Fahrten, die vorher enden, können angezeigt werden. <strong>Zu Zielstation</strong> zeigt nur Fahrten, die diese Station tatsächlich erreichen. Beispiel: U2 Richtung Niendorf Nord kann einen Kurzläufer nach Niendorf Markt enthalten; „Zu Zielstation Niendorf Nord“ nicht.</p></details>
 <h4>Linien und Ziele</h4><div data-routes>{routes}</div><button type="button" onclick="addRoute(this)">Route hinzufügen</button></article>'''
 
-        stations = "".join(
-            station_card(station, index)
-            for index, station in enumerate(raw_config.get("stations", []))
-        )
-        if not stations:
-            stations = station_card({"city": "Hamburg", "routes": []}, 0)
+        stations = "".join(station_card(station, index) for index, station in enumerate(raw_config.get("stations", []))) or station_card({"city":"Hamburg","routes":[]}, 0)
         raw = html.escape(json.dumps(raw_config, ensure_ascii=False))
-        content = f"""<div class="toolbar"><div><h1>Einstellungen</h1><div class="subtle">Bedienbare Felder · jede Änderung wird validiert</div></div><a href="/">← Abfahrten</a></div>{notice}
-<form method="post" action="/settings" accept-charset="UTF-8" onsubmit="return prepareConfig()"><section class="card"><h2>Weboberfläche</h2><p class="subtle">Benutzername: <code>hvv-anzeiger</code>. Das Webpasswort wird nicht angezeigt. Ein leeres Feld lässt den bisherigen Wert unverändert. Ändere das Standardpasswort vor der Nutzung im LAN.</p>
-<label for="web_password">Neues Webpasswort</label><input id="web_password" name="web_password" type="password" autocomplete="new-password" placeholder="unverändert lassen"></section>
-<section class="card"><h2>Geofox-Zugang</h2><p class="subtle">Das Passwort wird nicht angezeigt. Ein leeres Passwort lässt den bisherigen Wert unverändert.</p>
-<label for="user">Anwendungs-ID</label><input id="user" name="user" value="{html.escape(credentials.get("GEOFOX_USER", ""), quote=True)}" autocomplete="username">
-<label for="password">Passwort</label><input id="password" name="password" type="password" autocomplete="new-password" placeholder="unverändert lassen"></section>
-<section class="card"><h2>Geofox-API</h2><div class="grid">{scalar("api.base_url")}{scalar("api.version", "number")}{scalar("api.refresh_seconds", "number")}{scalar("api.request_timeout_seconds", "number")}{scalar("api.max_departures", "number")}{scalar("api.max_time_offset_minutes", "number")}{scalar("api.max_stale_age_minutes", "number")}</div></section>
-<section class="card"><h2>Display</h2><div class="grid">{scalar("display.spi_port", "number")}{scalar("display.spi_device", "number")}{scalar("display.gpio_dc", "number")}{scalar("display.gpio_reset", "number")}{scalar("display.rotate", "number")}{scalar("display.bus_speed_hz", "number")}{scalar("display.bgr")}</div></section>
-<section class="card"><h2>Nachtabschaltung</h2><div class="grid">{scalar("night_shutdown.enabled")}{scalar("night_shutdown.start", "time")}{scalar("night_shutdown.end", "time")}</div></section>
-<section class="card"><div class="station-heading"><div><h2>Haltestellen und Linien</h2><p class="subtle">Karten statt JSON: Namen, Kürzel und Ziele sind direkt verständlich editierbar.</p><p class="notice">Die Geofox-Treffer sind nur Vorschläge. Es gibt keine Garantie auf Vollständigkeit oder Korrektheit. Im Zweifel bitte die <a href="https://gti.geofox.de/" target="_blank" rel="noreferrer">offizielle Geofox-API-Dokumentation</a> prüfen.</p></div><button type="button" onclick="addStation()">Haltestelle hinzufügen</button></div><div id="stations">{stations}</div></section>
-<textarea id="config_json" name="config_json" hidden>{raw}</textarea><input type="hidden" name="csrf_token" value="{html.escape(self.csrf_token, quote=True)}"><p><button type="submit">Speichern und prüfen</button></p></form>{restart_notice}
+        content = f'''<div class="toolbar"><div><h1>Einstellungen</h1><div class="subtle">Bedienbare Felder · jede Änderung wird validiert</div></div><a href="/">← Abfahrten</a></div>{notice}
+<form method="post" action="/settings" accept-charset="UTF-8" onsubmit="return prepareConfig()"><section class="card"><h2>Weboberfläche</h2><p class="subtle">Benutzername: <code>hvv-anzeiger</code>. Ein leeres Passwortfeld lässt den bisherigen Wert unverändert.</p><label for="web_password">Neues Webpasswort</label><input id="web_password" name="web_password" type="password" autocomplete="new-password" placeholder="unverändert lassen"></section>
+<section class="card"><h2>Geofox-Zugang</h2><label for="user">Anwendungs-ID</label><input id="user" name="user" value="{html.escape(credentials.get("GEOFOX_USER", ""), quote=True)}" autocomplete="username"><label for="password">Passwort</label><input id="password" name="password" type="password" autocomplete="new-password" placeholder="unverändert lassen"></section>
+<section class="card"><h2>Geofox-API</h2><div class="grid">{scalar("api.base_url")}{scalar("api.version","number")}{scalar("api.refresh_seconds","number")}{scalar("api.request_timeout_seconds","number")}{scalar("api.max_departures","number")}{scalar("api.max_time_offset_minutes","number")}{scalar("api.max_stale_age_minutes","number")}</div></section>
+<section class="card"><h2>Display</h2><div class="grid">{scalar("display.spi_port","number")}{scalar("display.spi_device","number")}{scalar("display.gpio_dc","number")}{scalar("display.gpio_reset","number")}{scalar("display.rotate","number")}{scalar("display.bus_speed_hz","number")}{scalar("display.bgr")}</div></section>
+<section class="card"><h2>Nachtabschaltung</h2><div class="grid">{scalar("night_shutdown.enabled")}{scalar("night_shutdown.start","time")}{scalar("night_shutdown.end","time")}</div></section>
+<section class="card"><div class="station-heading"><div><h2>Haltestellen und Linien</h2><p class="subtle">Haltestelle eintippen, Geofox-Vorschlag auswählen; Name, Stadt und ID werden automatisch übernommen.</p></div><button type="button" onclick="addStation()">Haltestelle hinzufügen</button></div><div id="stations">{stations}</div></section>
+<textarea id="config_json" name="config_json" hidden>{raw}</textarea><input type="hidden" name="csrf_token" value="{html.escape(self.csrf_token, quote=True)}"><p><button id="save-settings" type="submit">Speichern und prüfen</button></p></form>
 <script>
-function resetField(button) {{ const control = button.parentElement.querySelector('[data-path]'); control.value = control.dataset.default; }}
-function addRoute(button) {{ const row = document.createElement('div'); row.className = 'route-row'; row.innerHTML = '<input data-route="line" placeholder="Linie" aria-label="Linie"><input data-route="destination" placeholder="Ziel" aria-label="Ziel"><button type="button" class="reset" onclick="this.parentElement.remove()">Route entfernen</button>'; button.previousElementSibling.appendChild(row); }}
-function addStation() {{ const first = document.querySelector('[data-station]'); const clone = first.cloneNode(true); clone.querySelectorAll('input').forEach(input => input.value = input.dataset.stationField === 'city' ? 'Hamburg' : ''); clone.querySelector('[data-routes]').innerHTML = ''; document.getElementById('stations').appendChild(clone); }}
-async function searchStation(button) {{ const card = button.closest('[data-station]'); const query = card.querySelector('[data-station-field="name"]').value; const city = card.querySelector('[data-station-field="city"]').value; const select = card.querySelector('[data-station-results]'); const message = card.querySelector('[data-search-message]'); message.textContent = 'Suche …'; try {{ const response = await fetch('/api/stations?q=' + encodeURIComponent(query) + '&city=' + encodeURIComponent(city)); const data = await response.json(); if (!response.ok) throw new Error(data.error || 'Suche fehlgeschlagen'); select.innerHTML = '<option value="">Treffer auswählen …</option>'; data.stations.forEach(station => {{ const option = document.createElement('option'); option.value = JSON.stringify(station); option.textContent = station.combinedName; select.appendChild(option); }}); message.textContent = data.stations.length ? 'Bitte passenden Treffer auswählen.' : 'Keine Treffer.'; }} catch (error) {{ message.textContent = error.message; }} }}
-function applyStation(select) {{ if (!select.value) return; const station = JSON.parse(select.value); const card = select.closest('[data-station]'); card.querySelector('[data-station-field="name"]').value = station.name; card.querySelector('[data-station-field="city"]').value = station.city; card.querySelector('[data-station-field="id"]').value = station.id; }}
-function prepareConfig() {{ const config = JSON.parse(document.getElementById('config_json').value); document.querySelectorAll('[data-path]').forEach(control => {{ const [section, key] = control.dataset.path.split('.'); config[section][key] = control.dataset.type === 'bool' ? control.value === 'true' : (control.type === 'number' ? Number(control.value) : control.value); }}); config.stations = [...document.querySelectorAll('[data-station]')].map(card => ({{ name: card.querySelector('[data-station-field="name"]').value, city: card.querySelector('[data-station-field="city"]').value, id: card.querySelector('[data-station-field="id"]').value || undefined, label: card.querySelector('[data-station-field="label"]').value, routes: [...card.querySelectorAll('[data-route="line"]')].map((line, index) => ({{ line: line.value, destination: card.querySelectorAll('[data-route="destination"]')[index].value }})) }})); document.getElementById('config_json').value = JSON.stringify(config); return true; }}
-</script>"""
+let requestSequence=0; let debounceTimers=new WeakMap(); let controllers=new WeakMap();
+function resetField(button){{const control=button.parentElement.querySelector('[data-path]');control.value=control.dataset.default}}
+function addRoute(button){{const row=document.createElement('div');row.className='route-row';row.innerHTML='<input data-route="line" placeholder="Linie" aria-label="Linie"><input data-route="destination" placeholder="Ziel" aria-label="Ziel"><button type="button" class="reset" onclick="this.parentElement.remove()">Route entfernen</button>';button.previousElementSibling.appendChild(row)}}
+function invalidateStation(card){{card.dataset.valid='false';card.querySelector('[data-station-field="id"]').value='';card.querySelector('[data-station-field="serviceTypes"]').value='[]';card.querySelector('[data-search-message]').textContent='Bitte Haltestelle aus einem Geofox-Vorschlag auswählen.'}}
+function bindStation(card){{const name=card.querySelector('[data-station-field="name"]');const city=card.querySelector('[data-station-field="city"]');[name,city].forEach(input=>input.addEventListener('input',()=>{{invalidateStation(card);scheduleStationSearch(card)}}));}}
+function scheduleStationSearch(card){{clearTimeout(debounceTimers.get(card));const query=card.querySelector('[data-station-field="name"]').value.trim();if(query.length<2) return;debounceTimers.set(card,setTimeout(()=>searchStation(card),350))}}
+async function searchStation(card){{const query=card.querySelector('[data-station-field="name"]').value.trim();const city=card.querySelector('[data-station-field="city"]').value.trim();const select=card.querySelector('[data-station-results]');const message=card.querySelector('[data-search-message]');const sequence=++requestSequence;controllers.get(card)?.abort();const controller=new AbortController();controllers.set(card,controller);select.disabled=true;message.innerHTML='<span class="spinner" aria-hidden="true"></span> Geofox wird abgefragt …';try{{const response=await fetch('/api/stations?q='+encodeURIComponent(query)+'&city='+encodeURIComponent(city),{{signal:controller.signal}});const data=await response.json();if(sequence!==requestSequence)return;if(!response.ok)throw new Error(data.error||'Geofox-Suche fehlgeschlagen');select.replaceChildren(new Option('Treffer auswählen …',''));data.stations.forEach(station=>{{const option=new Option(station.combinedName,JSON.stringify(station));select.appendChild(option)}});message.textContent=data.stations.length?'Bitte passenden Treffer auswählen.':'Keine passende Haltestelle gefunden.'}}catch(error){{if(error.name!=='AbortError')message.textContent=error.message}}finally{{if(sequence===requestSequence)select.disabled=false}}}}
+function applyStation(select){{if(!select.value)return;const station=JSON.parse(select.value);const card=select.closest('[data-station]');card.querySelector('[data-station-field="name"]').value=station.name;card.querySelector('[data-station-field="city"]').value=station.city;card.querySelector('[data-station-field="id"]').value=station.id;card.querySelector('[data-station-field="serviceTypes"]').value=JSON.stringify(station.serviceTypes||[]);card.dataset.valid='true';card.querySelector('[data-search-message]').innerHTML='<span class="ok">✓ Geofox-Haltestelle ausgewählt</span>'}}
+function addStation(){{const first=document.querySelector('[data-station]');const clone=first.cloneNode(true);clone.querySelectorAll('input').forEach(input=>input.value=input.dataset.stationField==='city'?'Hamburg':(input.dataset.stationField==='serviceTypes'?'[]':''));clone.querySelector('[data-routes]').innerHTML='';clone.querySelector('[data-station-results]').replaceChildren(new Option('Treffer auswählen …',''));invalidateStation(clone);document.getElementById('stations').appendChild(clone);bindStation(clone)}}
+function prepareConfig(){{const invalid=[...document.querySelectorAll('[data-station]')].find(card=>card.dataset.valid!=='true');if(invalid){{invalid.querySelector('[data-search-message]').innerHTML='<span class="error">Bitte zuerst einen gültigen Geofox-Vorschlag auswählen.</span>';invalid.scrollIntoView({{behavior:'smooth',block:'center'}});return false}}const config=JSON.parse(document.getElementById('config_json').value);document.querySelectorAll('[data-path]').forEach(control=>{{const [section,key]=control.dataset.path.split('.');config[section][key]=control.dataset.type==='bool'?control.value==='true':(control.type==='number'?Number(control.value):control.value)}});config.stations=[...document.querySelectorAll('[data-station]')].map(card=>({{name:card.querySelector('[data-station-field="name"]').value,city:card.querySelector('[data-station-field="city"]').value,id:card.querySelector('[data-station-field="id"]').value,label:card.querySelector('[data-station-field="label"]').value,serviceTypes:JSON.parse(card.querySelector('[data-station-field="serviceTypes"]').value||'[]'),routes:[...card.querySelectorAll('[data-route="line"]')].map((line,index)=>({{line:line.value,destination:card.querySelectorAll('[data-route="destination"]')[index].value}}))}}));document.getElementById('config_json').value=JSON.stringify(config);document.getElementById('save-settings').disabled=true;document.getElementById('save-settings').textContent='Geofox prüft …';return true}}
+document.querySelectorAll('[data-station]').forEach(bindStation);document.querySelectorAll('[data-station-results]').forEach(select=>select.addEventListener('change',()=>applyStation(select)));
+</script>'''
         return _page("Einstellungen", content)
+
+
+def _geofox_http_status(exc: GeofoxError) -> HTTPStatus:
+    if exc.http_status == 429:
+        return HTTPStatus.TOO_MANY_REQUESTS
+    if exc.http_status in (401, 403):
+        return HTTPStatus.BAD_GATEWAY
+    if exc.kind == "temporary" or exc.http_status in (500, 503):
+        return HTTPStatus.SERVICE_UNAVAILABLE
+    return HTTPStatus.BAD_REQUEST
 
 
 def make_handler(application: WebApplication) -> type[BaseHTTPRequestHandler]:
@@ -447,84 +359,77 @@ def make_handler(application: WebApplication) -> type[BaseHTTPRequestHandler]:
                 raise ValueError("Ungültige Anfragegröße") from exc
             if length < 0:
                 raise ValueError("Ungültige Anfragegröße")
-            payload = self.rfile.read(min(length, max_length))
+            if length > max_length:
+                raise OverflowError("Anfrage ist zu groß")
+            payload = self.rfile.read(length)
             try:
                 form_text = payload.decode("utf-8")
             except UnicodeDecodeError:
-                # Some embedded browsers still submit form bodies as Latin-1.
                 form_text = payload.decode("latin-1")
             return parse_qs(form_text, keep_blank_values=True)
+
+        def _security_headers(self) -> None:
+            self.send_header("Cache-Control", "no-store")
+            self.send_header("X-Content-Type-Options", "nosniff")
+            self.send_header("Referrer-Policy", "no-referrer")
+            self.send_header("X-Frame-Options", "DENY")
 
         def _send(self, payload: bytes, status: HTTPStatus = HTTPStatus.OK) -> None:
             self.send_response(status)
             self.send_header("Content-Type", "text/html; charset=utf-8")
             self.send_header("Content-Length", str(len(payload)))
-            self.send_header("Cache-Control", "no-store")
+            self._security_headers()
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def _send_json(self, data: dict[str, Any], status: HTTPStatus = HTTPStatus.OK, *, retry_after: int | None = None) -> None:
+            payload = json.dumps(data, ensure_ascii=False).encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json; charset=utf-8")
+            self.send_header("Content-Length", str(len(payload)))
+            if retry_after:
+                self.send_header("Retry-After", str(retry_after))
+            self._security_headers()
             self.end_headers()
             self.wfile.write(payload)
 
         def _unauthorized(self) -> None:
             self.send_response(HTTPStatus.UNAUTHORIZED)
             self.send_header("WWW-Authenticate", 'Basic realm="hvv-anzeiger"')
-            self.send_header("Cache-Control", "no-store")
+            self._security_headers()
             self.end_headers()
 
         def do_GET(self) -> None:  # noqa: N802
             if not application.authorize(self.headers):
-                self._unauthorized()
-                return
+                self._unauthorized(); return
             path = urlsplit(self.path).path
             if path == "/":
-                self._send(application.dashboard())
-            elif path == "/settings":
-                try:
-                    query = parse_qs(urlsplit(self.path).query)
-                    saved = query.get("saved", [""])[0] == "1"
-                    self._send(application.settings(
-                        "Gespeichert. Die laufende Anwendung übernimmt die Änderung bei der nächsten Aktualisierung; ein Neustart ist nicht nötig."
-                        if saved else "",
-                        restart_required=False,
-                    ))
-                except (ConfigError, OSError) as exc:
-                    self._send(application.settings(str(exc)), HTTPStatus.INTERNAL_SERVER_ERROR)
-            elif path == "/api/departures":
+                self._send(application.dashboard()); return
+            if path == "/settings":
+                query = parse_qs(urlsplit(self.path).query)
+                self._send(application.settings("Gespeichert. Die laufende Anwendung übernimmt die Änderung bei der nächsten Aktualisierung; ein Neustart ist nicht nötig." if query.get("saved", [""])[0] == "1" else "")); return
+            if path == "/api/departures":
                 try:
                     departures, error = application.departures()
-                    payload = json.dumps({"departures": departures, "error": error}).encode()
-                    self.send_response(HTTPStatus.OK)
-                    self.send_header("Content-Type", "application/json")
-                    self.send_header("Content-Length", str(len(payload)))
-                    self.end_headers()
-                    self.wfile.write(payload)
-                except (ConfigError, GeofoxError, OSError):
-                    self._send(application.dashboard())
-            elif path == "/api/stations":
+                    self._send_json({"departures": departures, "error": error})
+                except (ConfigError, GeofoxError, OSError) as exc:
+                    self._send_json({"departures": [], "error": str(exc)}, HTTPStatus.SERVICE_UNAVAILABLE)
+                return
+            if path == "/api/stations":
                 query = parse_qs(urlsplit(self.path).query)
                 try:
-                    stations = application.station_suggestions(
-                        query.get("q", [""])[0], query.get("city", ["Hamburg"])[0]
-                    )
-                    payload = json.dumps(
-                        {"stations": stations}, ensure_ascii=False
-                    ).encode()
-                    self.send_response(HTTPStatus.OK)
-                except (ConfigError, GeofoxError, OSError, ValueError) as exc:
-                    payload = json.dumps(
-                        {"stations": [], "error": str(exc)}, ensure_ascii=False
-                    ).encode()
-                    self.send_response(HTTPStatus.BAD_REQUEST)
-                self.send_header("Content-Type", "application/json; charset=utf-8")
-                self.send_header("Content-Length", str(len(payload)))
-                self.send_header("Cache-Control", "no-store")
-                self.end_headers()
-                self.wfile.write(payload)
-            else:
-                self.send_error(HTTPStatus.NOT_FOUND)
+                    stations = application.station_suggestions(query.get("q", [""])[0], query.get("city", ["Hamburg"])[0])
+                    self._send_json({"stations": stations})
+                except GeofoxError as exc:
+                    self._send_json({"stations": [], "error": str(exc)}, _geofox_http_status(exc), retry_after=exc.retry_after_seconds)
+                except (ConfigError, OSError, ValueError) as exc:
+                    self._send_json({"stations": [], "error": str(exc)}, HTTPStatus.BAD_REQUEST)
+                return
+            self.send_error(HTTPStatus.NOT_FOUND)
 
         def do_POST(self) -> None:  # noqa: N802
             if not application.authorize(self.headers):
-                self._unauthorized()
-                return
+                self._unauthorized(); return
             path = urlsplit(self.path).path
             if path == "/system/restart":
                 try:
@@ -532,42 +437,43 @@ def make_handler(application: WebApplication) -> type[BaseHTTPRequestHandler]:
                     application.validate_csrf(values.get("csrf_token", [""])[0])
                     application.restart_system()
                     self._send(_page("Neustart", "<h1>Neustart ausgelöst</h1>"))
+                except OverflowError as exc:
+                    self._send(_page("Fehler", f"<h1>{html.escape(str(exc))}</h1>"), HTTPStatus.REQUEST_ENTITY_TOO_LARGE)
                 except (OSError, PermissionError, ValueError, UnicodeDecodeError) as exc:
-                    self._send(application.dashboard() + f"<!-- {html.escape(str(exc))} -->".encode(), HTTPStatus.FORBIDDEN)
+                    self._send(_page("Fehler", f"<h1>{html.escape(str(exc))}</h1>"), HTTPStatus.FORBIDDEN)
                 return
             if path != "/settings":
-                self.send_error(HTTPStatus.NOT_FOUND)
-                return
+                self.send_error(HTTPStatus.NOT_FOUND); return
             try:
-                values = self._form_values(1_000_000)
+                values = self._form_values(MAX_FORM_BYTES)
                 application.validate_csrf(values.get("csrf_token", [""])[0])
                 raw_config = json.loads(values.get("config_json", [""])[0])
                 if not isinstance(raw_config, dict):
                     raise ValueError("Konfiguration muss ein JSON-Objekt sein")
-                candidate = self.server.application.config_path  # type: ignore[attr-defined]
-                with tempfile.NamedTemporaryFile(
-                    mode="w", encoding="utf-8", suffix=".json", delete=False
-                ) as handle:
-                    handle.write(json.dumps(raw_config, ensure_ascii=False))
-                    temporary = Path(handle.name)
+                current = load_credentials(application.credentials_path)
+                user = values.get("user", [""])[0].strip()
+                supplied_password = values.get("password", [""])[0]
+                password = supplied_password or current.get("GEOFOX_PASSWORD", "")
+                raw_config = application.validate_station_config(raw_config, user=user, password=password)
+                with tempfile.NamedTemporaryFile(mode="w", encoding="utf-8", suffix=".json", delete=False) as handle:
+                    handle.write(json.dumps(raw_config, ensure_ascii=False)); temporary = Path(handle.name)
                 try:
                     load_config(temporary)
                 finally:
                     temporary.unlink(missing_ok=True)
-                user = values.get("user", [""])[0].strip()
-                password = values.get("password", [""])[0]
                 web_password = values.get("web_password", [""])[0]
-                current = load_credentials(application.credentials_path)
                 if web_password:
                     application.save_web_password(web_password)
-                save_config(candidate, raw_config)
-                if password:
-                    save_credentials(application.credentials_path, user, password)
+                save_config(application.config_path, raw_config)
+                if supplied_password:
+                    save_credentials(application.credentials_path, user, supplied_password)
                 elif user != current.get("GEOFOX_USER", ""):
-                    save_credentials(application.credentials_path, user, current.get("GEOFOX_PASSWORD", ""))
-                self.send_response(HTTPStatus.SEE_OTHER)
-                self.send_header("Location", "/settings?saved=1")
-                self.end_headers()
+                    save_credentials(application.credentials_path, user, password)
+                self.send_response(HTTPStatus.SEE_OTHER); self.send_header("Location", "/settings?saved=1"); self._security_headers(); self.end_headers()
+            except OverflowError as exc:
+                self._send(application.settings(f"Nicht gespeichert: {exc}"), HTTPStatus.REQUEST_ENTITY_TOO_LARGE)
+            except GeofoxError as exc:
+                self._send(application.settings(f"Nicht gespeichert: {exc}"), _geofox_http_status(exc))
             except (ValueError, ConfigError, OSError, PermissionError) as exc:
                 self._send(application.settings(f"Nicht gespeichert: {exc}"), HTTPStatus.BAD_REQUEST)
 
@@ -580,17 +486,8 @@ def make_handler(application: WebApplication) -> type[BaseHTTPRequestHandler]:
 def run(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT, *, config: str = "config.json", credentials: str | None = None, cache: str = "var/stations.json", access_token: str | None = None) -> None:
     if host not in {"127.0.0.1", "localhost", "::1"} and not access_token:
         raise ValueError("Für einen nicht-lokalen Webhost muss HVV_WEB_PASSWORD_HASH gesetzt sein")
-    config_path = Path(config)
-    credentials_path = Path(credentials or os.environ.get("HVV_CREDENTIALS_FILE", "var/credentials.env"))
-    application = WebApplication(
-        config_path,
-        credentials_path,
-        Path(cache),
-        access_token=access_token,
-        web_env_path=Path(os.environ.get("HVV_WEB_ENV_FILE", "var/web.env")),
-    )
-    server = ThreadingHTTPServer((host, port), make_handler(application))
-    server.application = application  # type: ignore[attr-defined]
+    application = WebApplication(Path(config), Path(credentials or os.environ.get("HVV_CREDENTIALS_FILE", "var/credentials.env")), Path(cache), access_token=access_token, web_env_path=Path(os.environ.get("HVV_WEB_ENV_FILE", "var/web.env")))
+    server = ThreadingHTTPServer((host, port), make_handler(application)); server.application = application  # type: ignore[attr-defined]
     LOG.info("Lokale Weboberfläche erreichbar unter http://%s:%d", host, port)
     try:
         server.serve_forever()
@@ -602,19 +499,8 @@ def run(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT, *, config: str = "co
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Lokale Weboberfläche für den HVV-Anzeiger")
-    parser.add_argument("--host", default=os.environ.get("HVV_WEB_HOST", DEFAULT_HOST))
-    parser.add_argument("--port", type=int, default=int(os.environ.get("HVV_WEB_PORT", DEFAULT_PORT)))
-    parser.add_argument("--config", default=os.environ.get("HVV_CONFIG", "config.json"))
-    parser.add_argument("--credentials", default=os.environ.get("HVV_CREDENTIALS_FILE", "var/credentials.env"))
-    parser.add_argument("--cache", default=os.environ.get("HVV_STATION_CACHE", "var/stations.json"))
-    parser.add_argument(
-        "--access-token",
-        default=os.environ.get("HVV_WEB_PASSWORD_HASH"),
-        help="Gesalzener Passwort-Hash für nicht-lokale Zugriffe",
-    )
-    args = parser.parse_args()
-    logging.basicConfig(level=os.environ.get("LOG_LEVEL", "INFO").upper())
-    run(args.host, args.port, config=args.config, credentials=args.credentials, cache=args.cache, access_token=args.access_token)
+    parser.add_argument("--host", default=os.environ.get("HVV_WEB_HOST", DEFAULT_HOST)); parser.add_argument("--port", type=int, default=int(os.environ.get("HVV_WEB_PORT", DEFAULT_PORT))); parser.add_argument("--config", default=os.environ.get("HVV_CONFIG", "config.json")); parser.add_argument("--credentials", default=os.environ.get("HVV_CREDENTIALS_FILE", "var/credentials.env")); parser.add_argument("--cache", default=os.environ.get("HVV_STATION_CACHE", "var/stations.json")); parser.add_argument("--access-token", default=os.environ.get("HVV_WEB_PASSWORD_HASH"), help="Gesalzener Passwort-Hash für nicht-lokale Zugriffe")
+    args = parser.parse_args(); logging.basicConfig(level=os.environ.get("LOG_LEVEL", "INFO").upper()); run(args.host, args.port, config=args.config, credentials=args.credentials, cache=args.cache, access_token=args.access_token)
 
 
 if __name__ == "__main__":

--- a/hvv_display/web.py
+++ b/hvv_display/web.py
@@ -70,12 +70,18 @@ def verify_web_password(password: str, encoded: str) -> bool:
 def save_credentials(path: Path, user: str, password: str) -> None:
     if not user.strip() or not password:
         raise ValueError("Geofox-Anwendungs-ID und Passwort müssen ausgefüllt sein")
-    if any(character in user or character in password for character in ("\r", "\n", "\x00")):
+    if any(
+        character in user or character in password for character in ("\r", "\n", "\x00")
+    ):
         raise ValueError("Geofox-Zugangsdaten dürfen keine Zeilenumbrüche enthalten")
     path.parent.mkdir(parents=True, exist_ok=True)
     payload = f"GEOFOX_USER={user.strip()}\nGEOFOX_PASSWORD={password}\n"
     with tempfile.NamedTemporaryFile(
-        mode="w", encoding="utf-8", dir=path.parent, prefix=f".{path.name}.", delete=False
+        mode="w",
+        encoding="utf-8",
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        delete=False,
     ) as handle:
         handle.write(payload)
         temporary = Path(handle.name)
@@ -94,7 +100,11 @@ def save_config(path: Path, raw_config: dict[str, Any]) -> None:
     mode = path.stat().st_mode & 0o777 if path.exists() else 0o600
     try:
         with tempfile.NamedTemporaryFile(
-            mode="w", encoding="utf-8", dir=path.parent, prefix=f".{path.name}.", delete=False
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            delete=False,
         ) as handle:
             handle.write(payload)
             temporary = Path(handle.name)
@@ -167,12 +177,22 @@ def _page(title: str, content: str) -> bytes:
 
 
 class WebApplication:
-    def __init__(self, config_path: Path, credentials_path: Path, cache_path: Path, *, access_token: str | None = None, web_env_path: Path | None = None) -> None:
+    def __init__(
+        self,
+        config_path: Path,
+        credentials_path: Path,
+        cache_path: Path,
+        *,
+        access_token: str | None = None,
+        web_env_path: Path | None = None,
+    ) -> None:
         self.config_path = config_path
         self.credentials_path = credentials_path
         self.cache_path = cache_path
         self.access_token = access_token
-        self.web_env_path = web_env_path or Path(os.environ.get("HVV_WEB_ENV_FILE", "var/web.env"))
+        self.web_env_path = web_env_path or Path(
+            os.environ.get("HVV_WEB_ENV_FILE", "var/web.env")
+        )
         self.csrf_token = secrets.token_urlsafe(32)
 
     def authorize(self, headers: Any) -> bool:
@@ -186,15 +206,23 @@ class WebApplication:
         except (binascii.Error, UnicodeDecodeError):
             return False
         username, separator, password = decoded.partition(":")
-        return separator == ":" and username == "hvv-anzeiger" and verify_web_password(password, self.access_token)
+        return (
+            separator == ":"
+            and username == "hvv-anzeiger"
+            and verify_web_password(password, self.access_token)
+        )
 
     def validate_csrf(self, token: str) -> None:
         if not secrets.compare_digest(token, self.csrf_token):
             raise PermissionError("Ungültige Sitzungsbestätigung")
 
     def save_web_password(self, password: str) -> None:
-        if not password or any(character in password for character in ("\r", "\n", "\x00", '"', "\\")):
-            raise ValueError("Das Webpasswort darf nicht leer sein oder Sonderzeichen für die Env-Datei enthalten")
+        if not password or any(
+            character in password for character in ("\r", "\n", "\x00", '"', "\\")
+        ):
+            raise ValueError(
+                "Das Webpasswort darf nicht leer sein oder Sonderzeichen für die Env-Datei enthalten"
+            )
         self.web_env_path.parent.mkdir(parents=True, exist_ok=True)
         temporary = self.web_env_path.with_name(f".{self.web_env_path.name}.tmp")
         encoded = hash_web_password(password)
@@ -211,17 +239,28 @@ class WebApplication:
 
     @staticmethod
     def restart_system() -> None:
-        result = subprocess.run(["/usr/bin/sudo", "-n", "systemctl", "reboot"], check=False, capture_output=True, text=True)
+        result = subprocess.run(
+            ["/usr/bin/sudo", "-n", "systemctl", "reboot"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
         if result.returncode:
-            raise OSError("Systemneustart wurde abgelehnt; systemctl-Berechtigung prüfen")
+            raise OSError(
+                "Systemneustart wurde abgelehnt; systemctl-Berechtigung prüfen"
+            )
 
-    def _client(self, *, user: str | None = None, password: str | None = None) -> GeofoxClient:
+    def _client(
+        self, *, user: str | None = None, password: str | None = None
+    ) -> GeofoxClient:
         config = load_config(self.config_path)
         credentials = load_credentials(self.credentials_path)
         return GeofoxClient(
             config.api.base_url,
             user if user is not None else credentials.get("GEOFOX_USER", ""),
-            password if password is not None else credentials.get("GEOFOX_PASSWORD", ""),
+            password
+            if password is not None
+            else credentials.get("GEOFOX_PASSWORD", ""),
             version=config.api.version,
             timeout=config.api.request_timeout_seconds,
         )
@@ -231,7 +270,12 @@ class WebApplication:
         config = load_config(self.config_path)
         client = self._client()
         stations = resolve_stations(client, config.stations, self.cache_path)
-        departures = client.departure_list(stations, now=now, max_list=30, max_time_offset=config.api.max_time_offset_minutes)
+        departures = client.departure_list(
+            stations,
+            now=now,
+            max_list=30,
+            max_time_offset=config.api.max_time_offset_minutes,
+        )
         return _departure_payload(departures[: config.api.max_departures], now), None
 
     def station_suggestions(self, query: str, city: str) -> list[dict[str, Any]]:
@@ -243,7 +287,9 @@ class WebApplication:
             raise ValueError("Suchbegriff oder Stadt ist zu lang")
         return self._client().find_stations(query, city)
 
-    def validate_station_config(self, raw_config: dict[str, Any], *, user: str, password: str) -> dict[str, Any]:
+    def validate_station_config(
+        self, raw_config: dict[str, Any], *, user: str, password: str
+    ) -> dict[str, Any]:
         stations = raw_config.get("stations")
         if not isinstance(stations, list) or not stations:
             raise ValueError("Mindestens eine Haltestelle muss konfiguriert sein")
@@ -255,13 +301,23 @@ class WebApplication:
             city = str(station.get("city") or "Hamburg").strip()
             station_id = str(station.get("id") or "").strip()
             if not name or not station_id:
-                raise ValueError(f"Haltestelle {index + 1}: Bitte einen Geofox-Vorschlag auswählen")
-            if len(name) > MAX_QUERY_LENGTH or len(city) > MAX_CITY_LENGTH or len(station_id) > MAX_STATION_ID_LENGTH:
+                raise ValueError(
+                    f"Haltestelle {index + 1}: Bitte einen Geofox-Vorschlag auswählen"
+                )
+            if (
+                len(name) > MAX_QUERY_LENGTH
+                or len(city) > MAX_CITY_LENGTH
+                or len(station_id) > MAX_STATION_ID_LENGTH
+            ):
                 raise ValueError(f"Haltestelle {index + 1}: Eingabe ist zu lang")
             matches = client.find_stations(name, city)
-            match = next((item for item in matches if item.get("id") == station_id), None)
+            match = next(
+                (item for item in matches if item.get("id") == station_id), None
+            )
             if match is None:
-                raise ValueError(f"Haltestelle {index + 1}: Geofox findet die ausgewählte Haltestelle nicht mehr")
+                raise ValueError(
+                    f"Haltestelle {index + 1}: Geofox findet die ausgewählte Haltestelle nicht mehr"
+                )
             station["name"] = match["name"]
             station["city"] = match["city"]
             station["id"] = match["id"]
@@ -273,10 +329,13 @@ class WebApplication:
             departures, error = self.departures()
         except (ConfigError, GeofoxError, OSError) as exc:
             departures, error = [], str(exc)
-        rows = "".join(
-            f'<div class="row"><div><div class="line">{html.escape(item["line"])}</div><div class="station">{html.escape(item["station"])}</div></div><div class="destination">{html.escape(item["destination"])}{(" <span class=delay>(+" + str(item["delay_seconds"] // 60) + " min)</span>") if item["delay_seconds"] else ""}</div><div class="time {"cancelled" if item["cancelled"] else ""}">{item["time"]}<br><small>in {item["minutes"]} min</small></div></div>'
-            for item in departures
-        ) or '<div class="empty">Keine passende Abfahrt verfügbar.</div>'
+        rows = (
+            "".join(
+                f'<div class="row"><div><div class="line">{html.escape(item["line"])}</div><div class="station">{html.escape(item["station"])}</div></div><div class="destination">{html.escape(item["destination"])}{(" <span class=delay>(+" + str(item["delay_seconds"] // 60) + " min)</span>") if item["delay_seconds"] else ""}</div><div class="time {"cancelled" if item["cancelled"] else ""}">{item["time"]}<br><small>in {item["minutes"]} min</small></div></div>'
+                for item in departures
+            )
+            or '<div class="empty">Keine passende Abfahrt verfügbar.</div>'
+        )
         message = f'<div class="notice">{html.escape(error)}</div>' if error else ""
         status = hardware_status()
         content = f'''<div class="toolbar"><div><h1>Abfahrten</h1><div class="subtle">Lokale HVV-Anzeige · aktualisiert beim Öffnen</div></div><div><a href="/settings">Einstellungen</a> · <a href="/">Aktualisieren</a></div></div>{message}<section class="board" aria-label="Abfahrtsanzeige">{rows}</section><section class="status" aria-label="Hardware-Status"><div>CPU<strong>{html.escape(status["cpu"])}</strong></div><div>RAM<strong>{html.escape(status["ram"])}</strong></div><div>SD-Speicher<strong>{html.escape(status["storage"])}</strong></div></section><form method="post" action="/system/restart" onsubmit="return confirm('Raspberry Pi wirklich neu starten?');"><input type="hidden" name="csrf_token" value="{html.escape(self.csrf_token, quote=True)}"><button class="danger" type="submit">System neu starten</button></form>'''
@@ -286,8 +345,44 @@ class WebApplication:
         raw_config = self.raw_config()
         credentials = load_credentials(self.credentials_path)
         notice = f'<div class="notice">{html.escape(message)}</div>' if message else ""
-        defaults = {"api.base_url":"https://gti.geofox.de/gti/public","api.version":63,"api.refresh_seconds":15,"api.request_timeout_seconds":8,"api.max_departures":5,"api.max_time_offset_minutes":90,"api.max_stale_age_minutes":5,"display.spi_port":0,"display.spi_device":0,"display.gpio_dc":24,"display.gpio_reset":25,"display.rotate":0,"display.bus_speed_hz":16000000,"display.bgr":False,"night_shutdown.enabled":False,"night_shutdown.start":"21:00","night_shutdown.end":"06:30"}
-        descriptions = {"api.base_url":"Offizielle HTTPS-Adresse der Geofox-Schnittstelle.","api.version":"API-Version des Geofox-Vertrags.","api.refresh_seconds":"Sekunden zwischen Abfragen; mindestens 15.","api.request_timeout_seconds":"Maximale Wartezeit pro Anfrage.","api.max_departures":"Sichtbare Abfahrten; 1 bis 5.","api.max_time_offset_minutes":"Wie weit in die Zukunft gesucht wird.","api.max_stale_age_minutes":"Wie lange alte Daten sichtbar bleiben.","display.spi_port":"Nummer des SPI-Busses.","display.spi_device":"Chip-Select des Displays.","display.gpio_dc":"GPIO für Data/Command.","display.gpio_reset":"GPIO für Display-Reset.","display.rotate":"Drehung: 0 bis 3 Vierteldrehungen.","display.bus_speed_hz":"SPI-Takt in Hertz.","display.bgr":"Bei vertauschten Rot-/Blaukanälen aktivieren.","night_shutdown.enabled":"Pausiert nachts Abfragen und Display.","night_shutdown.start":"Beginn in Hamburger Ortszeit (HH:MM).","night_shutdown.end":"Ende in Hamburger Ortszeit (HH:MM)."}
+        defaults = {
+            "api.base_url": "https://gti.geofox.de/gti/public",
+            "api.version": 63,
+            "api.refresh_seconds": 15,
+            "api.request_timeout_seconds": 8,
+            "api.max_departures": 5,
+            "api.max_time_offset_minutes": 90,
+            "api.max_stale_age_minutes": 5,
+            "display.spi_port": 0,
+            "display.spi_device": 0,
+            "display.gpio_dc": 24,
+            "display.gpio_reset": 25,
+            "display.rotate": 0,
+            "display.bus_speed_hz": 16000000,
+            "display.bgr": False,
+            "night_shutdown.enabled": False,
+            "night_shutdown.start": "21:00",
+            "night_shutdown.end": "06:30",
+        }
+        descriptions = {
+            "api.base_url": "Offizielle HTTPS-Adresse der Geofox-Schnittstelle.",
+            "api.version": "API-Version des Geofox-Vertrags.",
+            "api.refresh_seconds": "Sekunden zwischen Abfragen; mindestens 15.",
+            "api.request_timeout_seconds": "Maximale Wartezeit pro Anfrage.",
+            "api.max_departures": "Sichtbare Abfahrten; 1 bis 5.",
+            "api.max_time_offset_minutes": "Wie weit in die Zukunft gesucht wird.",
+            "api.max_stale_age_minutes": "Wie lange alte Daten sichtbar bleiben.",
+            "display.spi_port": "Nummer des SPI-Busses.",
+            "display.spi_device": "Chip-Select des Displays.",
+            "display.gpio_dc": "GPIO für Data/Command.",
+            "display.gpio_reset": "GPIO für Display-Reset.",
+            "display.rotate": "Drehung: 0 bis 3 Vierteldrehungen.",
+            "display.bus_speed_hz": "SPI-Takt in Hertz.",
+            "display.bgr": "Bei vertauschten Rot-/Blaukanälen aktivieren.",
+            "night_shutdown.enabled": "Pausiert nachts Abfragen und Display.",
+            "night_shutdown.start": "Beginn in Hamburger Ortszeit (HH:MM).",
+            "night_shutdown.end": "Ende in Hamburger Ortszeit (HH:MM).",
+        }
 
         def scalar(path: str, input_type: str = "text") -> str:
             section, key = path.split(".")
@@ -305,23 +400,28 @@ class WebApplication:
                 for route in station.get("routes", [])
             )
             valid = bool(station.get("id"))
-            service_types = json.dumps(station.get("serviceTypes", []), ensure_ascii=False)
+            service_types = json.dumps(
+                station.get("serviceTypes", []), ensure_ascii=False
+            )
             return f'''<article class="station-card" data-station data-valid="{str(valid).lower()}">
 <div class="station-heading"><h3>Haltestelle {index + 1}</h3><button type="button" class="reset" onclick="this.closest('[data-station]').remove()">Haltestelle entfernen</button></div>
 <div class="grid"><div><label>Name</label><input data-station-field="name" maxlength="{MAX_QUERY_LENGTH}" value="{html.escape(str(station.get("name", "")), quote=True)}" required autocomplete="off"><div class="subtle">Mindestens 2 Zeichen. Vorschläge erscheinen automatisch.</div></div><div><label>Stadt</label><input data-station-field="city" maxlength="{MAX_CITY_LENGTH}" value="{html.escape(str(station.get("city", "Hamburg")), quote=True)}" required><div class="subtle">Wird nach Auswahl aus Geofox übernommen.</div></div><div><label>Geofox-ID</label><input data-station-field="id" maxlength="{MAX_STATION_ID_LENGTH}" value="{html.escape(str(station.get("id") or ""), quote=True)}" readonly tabindex="-1"><div class="subtle">Technisches Metadatum; wird automatisch gesetzt.</div></div><div><label>Kürzel</label><input data-station-field="label" maxlength="3" value="{html.escape(str(station.get("label", "")), quote=True)}" required><div class="subtle">1–3 Zeichen für die Anzeige.</div></div></div>
 <input type="hidden" data-station-field="serviceTypes" value="{html.escape(service_types, quote=True)}">
-<div class="station-search"><select data-station-results aria-label="Geofox-Haltestellenvorschläge"><option value="">Treffer auswählen …</option></select><span class="subtle" data-search-message>{'<span class="ok">✓ Geofox-Haltestelle ausgewählt</span>' if valid else 'Bitte Haltestelle aus einem Geofox-Vorschlag auswählen.'}</span></div>
+<div class="station-search"><select data-station-results aria-label="Geofox-Haltestellenvorschläge"><option value="">Treffer auswählen …</option></select><span class="subtle" data-search-message>{'<span class="ok">✓ Geofox-Haltestelle ausgewählt</span>' if valid else "Bitte Haltestelle aus einem Geofox-Vorschlag auswählen."}</span></div>
 <details class="help-box"><summary>Richtung oder Zielstation?</summary><p><strong>Richtung</strong> wählt später den Linienast; auch Fahrten, die vorher enden, können angezeigt werden. <strong>Zu Zielstation</strong> zeigt nur Fahrten, die diese Station tatsächlich erreichen. Beispiel: U2 Richtung Niendorf Nord kann einen Kurzläufer nach Niendorf Markt enthalten; „Zu Zielstation Niendorf Nord“ nicht.</p></details>
 <h4>Linien und Ziele</h4><div data-routes>{routes}</div><button type="button" onclick="addRoute(this)">Route hinzufügen</button></article>'''
 
-        stations = "".join(station_card(station, index) for index, station in enumerate(raw_config.get("stations", []))) or station_card({"city":"Hamburg","routes":[]}, 0)
+        stations = "".join(
+            station_card(station, index)
+            for index, station in enumerate(raw_config.get("stations", []))
+        ) or station_card({"city": "Hamburg", "routes": []}, 0)
         raw = html.escape(json.dumps(raw_config, ensure_ascii=False))
         content = f'''<div class="toolbar"><div><h1>Einstellungen</h1><div class="subtle">Bedienbare Felder · jede Änderung wird validiert</div></div><a href="/">← Abfahrten</a></div>{notice}
 <form method="post" action="/settings" accept-charset="UTF-8" onsubmit="return prepareConfig()"><section class="card"><h2>Weboberfläche</h2><p class="subtle">Benutzername: <code>hvv-anzeiger</code>. Ein leeres Passwortfeld lässt den bisherigen Wert unverändert.</p><label for="web_password">Neues Webpasswort</label><input id="web_password" name="web_password" type="password" autocomplete="new-password" placeholder="unverändert lassen"></section>
 <section class="card"><h2>Geofox-Zugang</h2><label for="user">Anwendungs-ID</label><input id="user" name="user" value="{html.escape(credentials.get("GEOFOX_USER", ""), quote=True)}" autocomplete="username"><label for="password">Passwort</label><input id="password" name="password" type="password" autocomplete="new-password" placeholder="unverändert lassen"></section>
-<section class="card"><h2>Geofox-API</h2><div class="grid">{scalar("api.base_url")}{scalar("api.version","number")}{scalar("api.refresh_seconds","number")}{scalar("api.request_timeout_seconds","number")}{scalar("api.max_departures","number")}{scalar("api.max_time_offset_minutes","number")}{scalar("api.max_stale_age_minutes","number")}</div></section>
-<section class="card"><h2>Display</h2><div class="grid">{scalar("display.spi_port","number")}{scalar("display.spi_device","number")}{scalar("display.gpio_dc","number")}{scalar("display.gpio_reset","number")}{scalar("display.rotate","number")}{scalar("display.bus_speed_hz","number")}{scalar("display.bgr")}</div></section>
-<section class="card"><h2>Nachtabschaltung</h2><div class="grid">{scalar("night_shutdown.enabled")}{scalar("night_shutdown.start","time")}{scalar("night_shutdown.end","time")}</div></section>
+<section class="card"><h2>Geofox-API</h2><div class="grid">{scalar("api.base_url")}{scalar("api.version", "number")}{scalar("api.refresh_seconds", "number")}{scalar("api.request_timeout_seconds", "number")}{scalar("api.max_departures", "number")}{scalar("api.max_time_offset_minutes", "number")}{scalar("api.max_stale_age_minutes", "number")}</div></section>
+<section class="card"><h2>Display</h2><div class="grid">{scalar("display.spi_port", "number")}{scalar("display.spi_device", "number")}{scalar("display.gpio_dc", "number")}{scalar("display.gpio_reset", "number")}{scalar("display.rotate", "number")}{scalar("display.bus_speed_hz", "number")}{scalar("display.bgr")}</div></section>
+<section class="card"><h2>Nachtabschaltung</h2><div class="grid">{scalar("night_shutdown.enabled")}{scalar("night_shutdown.start", "time")}{scalar("night_shutdown.end", "time")}</div></section>
 <section class="card"><div class="station-heading"><div><h2>Haltestellen und Linien</h2><p class="subtle">Haltestelle eintippen, Geofox-Vorschlag auswählen; Name, Stadt und ID werden automatisch übernommen.</p></div><button type="button" onclick="addStation()">Haltestelle hinzufügen</button></div><div id="stations">{stations}</div></section>
 <textarea id="config_json" name="config_json" hidden>{raw}</textarea><input type="hidden" name="csrf_token" value="{html.escape(self.csrf_token, quote=True)}"><p><button id="save-settings" type="submit">Speichern und prüfen</button></p></form>
 <script>
@@ -382,7 +482,13 @@ def make_handler(application: WebApplication) -> type[BaseHTTPRequestHandler]:
             self.end_headers()
             self.wfile.write(payload)
 
-        def _send_json(self, data: dict[str, Any], status: HTTPStatus = HTTPStatus.OK, *, retry_after: int | None = None) -> None:
+        def _send_json(
+            self,
+            data: dict[str, Any],
+            status: HTTPStatus = HTTPStatus.OK,
+            *,
+            retry_after: int | None = None,
+        ) -> None:
             payload = json.dumps(data, ensure_ascii=False).encode("utf-8")
             self.send_response(status)
             self.send_header("Content-Type", "application/json; charset=utf-8")
@@ -401,35 +507,56 @@ def make_handler(application: WebApplication) -> type[BaseHTTPRequestHandler]:
 
         def do_GET(self) -> None:  # noqa: N802
             if not application.authorize(self.headers):
-                self._unauthorized(); return
+                self._unauthorized()
+                return
             path = urlsplit(self.path).path
             if path == "/":
-                self._send(application.dashboard()); return
+                self._send(application.dashboard())
+                return
             if path == "/settings":
                 query = parse_qs(urlsplit(self.path).query)
-                self._send(application.settings("Gespeichert. Die laufende Anwendung übernimmt die Änderung bei der nächsten Aktualisierung; ein Neustart ist nicht nötig." if query.get("saved", [""])[0] == "1" else "")); return
+                self._send(
+                    application.settings(
+                        "Gespeichert. Die laufende Anwendung übernimmt die Änderung bei der nächsten Aktualisierung; ein Neustart ist nicht nötig."
+                        if query.get("saved", [""])[0] == "1"
+                        else ""
+                    )
+                )
+                return
             if path == "/api/departures":
                 try:
                     departures, error = application.departures()
                     self._send_json({"departures": departures, "error": error})
                 except (ConfigError, GeofoxError, OSError) as exc:
-                    self._send_json({"departures": [], "error": str(exc)}, HTTPStatus.SERVICE_UNAVAILABLE)
+                    self._send_json(
+                        {"departures": [], "error": str(exc)},
+                        HTTPStatus.SERVICE_UNAVAILABLE,
+                    )
                 return
             if path == "/api/stations":
                 query = parse_qs(urlsplit(self.path).query)
                 try:
-                    stations = application.station_suggestions(query.get("q", [""])[0], query.get("city", ["Hamburg"])[0])
+                    stations = application.station_suggestions(
+                        query.get("q", [""])[0], query.get("city", ["Hamburg"])[0]
+                    )
                     self._send_json({"stations": stations})
                 except GeofoxError as exc:
-                    self._send_json({"stations": [], "error": str(exc)}, _geofox_http_status(exc), retry_after=exc.retry_after_seconds)
+                    self._send_json(
+                        {"stations": [], "error": str(exc)},
+                        _geofox_http_status(exc),
+                        retry_after=exc.retry_after_seconds,
+                    )
                 except (ConfigError, OSError, ValueError) as exc:
-                    self._send_json({"stations": [], "error": str(exc)}, HTTPStatus.BAD_REQUEST)
+                    self._send_json(
+                        {"stations": [], "error": str(exc)}, HTTPStatus.BAD_REQUEST
+                    )
                 return
             self.send_error(HTTPStatus.NOT_FOUND)
 
         def do_POST(self) -> None:  # noqa: N802
             if not application.authorize(self.headers):
-                self._unauthorized(); return
+                self._unauthorized()
+                return
             path = urlsplit(self.path).path
             if path == "/system/restart":
                 try:
@@ -438,12 +565,24 @@ def make_handler(application: WebApplication) -> type[BaseHTTPRequestHandler]:
                     application.restart_system()
                     self._send(_page("Neustart", "<h1>Neustart ausgelöst</h1>"))
                 except OverflowError as exc:
-                    self._send(_page("Fehler", f"<h1>{html.escape(str(exc))}</h1>"), HTTPStatus.REQUEST_ENTITY_TOO_LARGE)
-                except (OSError, PermissionError, ValueError, UnicodeDecodeError) as exc:
-                    self._send(_page("Fehler", f"<h1>{html.escape(str(exc))}</h1>"), HTTPStatus.FORBIDDEN)
+                    self._send(
+                        _page("Fehler", f"<h1>{html.escape(str(exc))}</h1>"),
+                        HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+                    )
+                except (
+                    OSError,
+                    PermissionError,
+                    ValueError,
+                    UnicodeDecodeError,
+                ) as exc:
+                    self._send(
+                        _page("Fehler", f"<h1>{html.escape(str(exc))}</h1>"),
+                        HTTPStatus.FORBIDDEN,
+                    )
                 return
             if path != "/settings":
-                self.send_error(HTTPStatus.NOT_FOUND); return
+                self.send_error(HTTPStatus.NOT_FOUND)
+                return
             try:
                 values = self._form_values(MAX_FORM_BYTES)
                 application.validate_csrf(values.get("csrf_token", [""])[0])
@@ -454,9 +593,14 @@ def make_handler(application: WebApplication) -> type[BaseHTTPRequestHandler]:
                 user = values.get("user", [""])[0].strip()
                 supplied_password = values.get("password", [""])[0]
                 password = supplied_password or current.get("GEOFOX_PASSWORD", "")
-                raw_config = application.validate_station_config(raw_config, user=user, password=password)
-                with tempfile.NamedTemporaryFile(mode="w", encoding="utf-8", suffix=".json", delete=False) as handle:
-                    handle.write(json.dumps(raw_config, ensure_ascii=False)); temporary = Path(handle.name)
+                raw_config = application.validate_station_config(
+                    raw_config, user=user, password=password
+                )
+                with tempfile.NamedTemporaryFile(
+                    mode="w", encoding="utf-8", suffix=".json", delete=False
+                ) as handle:
+                    handle.write(json.dumps(raw_config, ensure_ascii=False))
+                    temporary = Path(handle.name)
                 try:
                     load_config(temporary)
                 finally:
@@ -466,16 +610,30 @@ def make_handler(application: WebApplication) -> type[BaseHTTPRequestHandler]:
                     application.save_web_password(web_password)
                 save_config(application.config_path, raw_config)
                 if supplied_password:
-                    save_credentials(application.credentials_path, user, supplied_password)
+                    save_credentials(
+                        application.credentials_path, user, supplied_password
+                    )
                 elif user != current.get("GEOFOX_USER", ""):
                     save_credentials(application.credentials_path, user, password)
-                self.send_response(HTTPStatus.SEE_OTHER); self.send_header("Location", "/settings?saved=1"); self._security_headers(); self.end_headers()
+                self.send_response(HTTPStatus.SEE_OTHER)
+                self.send_header("Location", "/settings?saved=1")
+                self._security_headers()
+                self.end_headers()
             except OverflowError as exc:
-                self._send(application.settings(f"Nicht gespeichert: {exc}"), HTTPStatus.REQUEST_ENTITY_TOO_LARGE)
+                self._send(
+                    application.settings(f"Nicht gespeichert: {exc}"),
+                    HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+                )
             except GeofoxError as exc:
-                self._send(application.settings(f"Nicht gespeichert: {exc}"), _geofox_http_status(exc))
+                self._send(
+                    application.settings(f"Nicht gespeichert: {exc}"),
+                    _geofox_http_status(exc),
+                )
             except (ValueError, ConfigError, OSError, PermissionError) as exc:
-                self._send(application.settings(f"Nicht gespeichert: {exc}"), HTTPStatus.BAD_REQUEST)
+                self._send(
+                    application.settings(f"Nicht gespeichert: {exc}"),
+                    HTTPStatus.BAD_REQUEST,
+                )
 
         def log_message(self, format: str, *args: object) -> None:
             LOG.info("web %s", format % args)
@@ -483,11 +641,30 @@ def make_handler(application: WebApplication) -> type[BaseHTTPRequestHandler]:
     return Handler
 
 
-def run(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT, *, config: str = "config.json", credentials: str | None = None, cache: str = "var/stations.json", access_token: str | None = None) -> None:
+def run(
+    host: str = DEFAULT_HOST,
+    port: int = DEFAULT_PORT,
+    *,
+    config: str = "config.json",
+    credentials: str | None = None,
+    cache: str = "var/stations.json",
+    access_token: str | None = None,
+) -> None:
     if host not in {"127.0.0.1", "localhost", "::1"} and not access_token:
-        raise ValueError("Für einen nicht-lokalen Webhost muss HVV_WEB_PASSWORD_HASH gesetzt sein")
-    application = WebApplication(Path(config), Path(credentials or os.environ.get("HVV_CREDENTIALS_FILE", "var/credentials.env")), Path(cache), access_token=access_token, web_env_path=Path(os.environ.get("HVV_WEB_ENV_FILE", "var/web.env")))
-    server = ThreadingHTTPServer((host, port), make_handler(application)); server.application = application  # type: ignore[attr-defined]
+        raise ValueError(
+            "Für einen nicht-lokalen Webhost muss HVV_WEB_PASSWORD_HASH gesetzt sein"
+        )
+    application = WebApplication(
+        Path(config),
+        Path(
+            credentials or os.environ.get("HVV_CREDENTIALS_FILE", "var/credentials.env")
+        ),
+        Path(cache),
+        access_token=access_token,
+        web_env_path=Path(os.environ.get("HVV_WEB_ENV_FILE", "var/web.env")),
+    )
+    server = ThreadingHTTPServer((host, port), make_handler(application))
+    server.application = application  # type: ignore[attr-defined]
     LOG.info("Lokale Weboberfläche erreichbar unter http://%s:%d", host, port)
     try:
         server.serve_forever()
@@ -498,9 +675,36 @@ def run(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT, *, config: str = "co
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Lokale Weboberfläche für den HVV-Anzeiger")
-    parser.add_argument("--host", default=os.environ.get("HVV_WEB_HOST", DEFAULT_HOST)); parser.add_argument("--port", type=int, default=int(os.environ.get("HVV_WEB_PORT", DEFAULT_PORT))); parser.add_argument("--config", default=os.environ.get("HVV_CONFIG", "config.json")); parser.add_argument("--credentials", default=os.environ.get("HVV_CREDENTIALS_FILE", "var/credentials.env")); parser.add_argument("--cache", default=os.environ.get("HVV_STATION_CACHE", "var/stations.json")); parser.add_argument("--access-token", default=os.environ.get("HVV_WEB_PASSWORD_HASH"), help="Gesalzener Passwort-Hash für nicht-lokale Zugriffe")
-    args = parser.parse_args(); logging.basicConfig(level=os.environ.get("LOG_LEVEL", "INFO").upper()); run(args.host, args.port, config=args.config, credentials=args.credentials, cache=args.cache, access_token=args.access_token)
+    parser = argparse.ArgumentParser(
+        description="Lokale Weboberfläche für den HVV-Anzeiger"
+    )
+    parser.add_argument("--host", default=os.environ.get("HVV_WEB_HOST", DEFAULT_HOST))
+    parser.add_argument(
+        "--port", type=int, default=int(os.environ.get("HVV_WEB_PORT", DEFAULT_PORT))
+    )
+    parser.add_argument("--config", default=os.environ.get("HVV_CONFIG", "config.json"))
+    parser.add_argument(
+        "--credentials",
+        default=os.environ.get("HVV_CREDENTIALS_FILE", "var/credentials.env"),
+    )
+    parser.add_argument(
+        "--cache", default=os.environ.get("HVV_STATION_CACHE", "var/stations.json")
+    )
+    parser.add_argument(
+        "--access-token",
+        default=os.environ.get("HVV_WEB_PASSWORD_HASH"),
+        help="Gesalzener Passwort-Hash für nicht-lokale Zugriffe",
+    )
+    args = parser.parse_args()
+    logging.basicConfig(level=os.environ.get("LOG_LEVEL", "INFO").upper())
+    run(
+        args.host,
+        args.port,
+        config=args.config,
+        credentials=args.credentials,
+        cache=args.cache,
+        access_token=args.access_token,
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_geofox.py
+++ b/tests/test_geofox.py
@@ -2,9 +2,11 @@ import base64
 import hashlib
 import hmac
 import unittest
+import urllib.error
 from datetime import datetime
+from unittest.mock import patch
 
-from hvv_display.geofox import HAMBURG_TZ, GeofoxClient, normalize, route_matches
+from hvv_display.geofox import HAMBURG_TZ, GeofoxClient, GeofoxError, normalize, route_matches
 from hvv_display.models import Route, Station
 
 
@@ -23,6 +25,10 @@ class FakeResponse:
 
 
 class GeofoxClientTest(unittest.TestCase):
+    def setUp(self) -> None:
+        GeofoxClient._global_last_request_at = 0.0
+        GeofoxClient._global_retry_until = 0.0
+
     def test_signature_is_hmac_sha1_base64_of_exact_body(self) -> None:
         client = GeofoxClient("https://example.test", "user", "secret")
         body = client.encode_body({"version": 63, "name": "Straße"})
@@ -38,38 +44,95 @@ class GeofoxClientTest(unittest.TestCase):
         self.assertFalse(route_matches("184", "S Elbgaustraße", routes))
         self.assertEqual(normalize("Recknitzstraße"), "recknitzstrasse")
 
+    def test_find_stations_returns_service_types_for_follow_up_flow(self) -> None:
+        response = FakeResponse(
+            b'{"returnCode":"OK","results":[{"type":"STATION","id":"Master:1",'
+            b'"name":"Jungfernstieg","city":"Hamburg","combinedName":"Hamburg, Jungfernstieg",'
+            b'"serviceTypes":["BUS","UBAHN","SBAHN"]}]}'
+        )
+        client = GeofoxClient(
+            "https://example.test", "user", "secret", min_request_interval=0,
+            urlopen=lambda *_args, **_kwargs: response,
+        )
+        result = client.find_stations("Jungfernstieg", "Hamburg")
+        self.assertEqual(result[0]["id"], "Master:1")
+        self.assertEqual(result[0]["serviceTypes"], ["BUS", "UBAHN", "SBAHN"])
+
+    def test_http_200_with_geofox_error_is_not_success(self) -> None:
+        response = FakeResponse(
+            b'{"returnCode":"ERROR_CN_TOO_MANY","errorDevInfo":"internal stack"}'
+        )
+        client = GeofoxClient(
+            "https://example.test", "user", "secret", min_request_interval=0,
+            urlopen=lambda *_args, **_kwargs: response,
+        )
+        with self.assertRaises(GeofoxError) as raised:
+            client.find_stations("Ha", "Hamburg")
+        self.assertEqual(raised.exception.return_code, "ERROR_CN_TOO_MANY")
+        self.assertEqual(raised.exception.kind, "validation")
+        self.assertNotIn("internal stack", str(raised.exception))
+
+    def test_error_text_is_sanitized_and_dev_info_is_hidden(self) -> None:
+        response = FakeResponse(
+            b'{"returnCode":"ERROR_TEXT","errorText":"Ung\u00fcltig\\nbitte pr\u00fcfen",'
+            b'"errorDevInfo":"secret internal details"}'
+        )
+        client = GeofoxClient(
+            "https://example.test", "user", "secret", min_request_interval=0,
+            urlopen=lambda *_args, **_kwargs: response,
+        )
+        with self.assertRaises(GeofoxError) as raised:
+            client.find_stations("Test", "Hamburg")
+        self.assertNotIn("secret internal details", str(raised.exception))
+        self.assertNotIn("\n", str(raised.exception))
+
+    def test_429_exposes_retry_after_and_updates_global_backoff(self) -> None:
+        error = urllib.error.HTTPError(
+            "https://example.test", 429, "Too Many", {"Retry-After": "3"}, None
+        )
+        client = GeofoxClient(
+            "https://example.test", "user", "secret", min_request_interval=0,
+            urlopen=lambda *_args, **_kwargs: (_ for _ in ()).throw(error),
+        )
+        with self.assertRaises(GeofoxError) as raised:
+            client.find_stations("Test", "Hamburg")
+        self.assertEqual(raised.exception.retry_after_seconds, 3)
+        self.assertEqual(raised.exception.http_status, 429)
+        self.assertGreater(GeofoxClient._global_retry_until, 0)
+
+    def test_rate_limit_is_shared_across_client_instances(self) -> None:
+        response = FakeResponse(b'{"returnCode":"OK","results":[]}')
+        first = GeofoxClient(
+            "https://example.test", "user", "secret", min_request_interval=1.05,
+            urlopen=lambda *_args, **_kwargs: response,
+        )
+        second = GeofoxClient(
+            "https://example.test", "user", "secret", min_request_interval=1.05,
+            urlopen=lambda *_args, **_kwargs: response,
+        )
+        with patch("hvv_display.geofox.time.sleep") as sleep, patch(
+            "hvv_display.geofox.time.monotonic", side_effect=[10.0, 10.0, 10.2, 11.25]
+        ):
+            first.find_stations("Test", "Hamburg")
+            second.find_stations("Test", "Hamburg")
+        sleep.assert_called_once()
+        self.assertAlmostEqual(sleep.call_args.args[0], 0.85, places=2)
+
     def test_departures_are_filtered_and_sorted(self) -> None:
         response = FakeResponse(
             b'{"returnCode":"OK","departures":['
-            b'{"line":{"name":"186","direction":"S Othmarschen"},'
-            b'"timeOffset":9,"delay":120},'
+            b'{"line":{"name":"186","direction":"S Othmarschen"},"timeOffset":9,"delay":120},'
             b'{"line":{"name":"1","direction":"Anderswo"},"timeOffset":2},'
-            b'{"line":{"name":"21","direction":"U Niendorf Nord"},'
-            b'"station":{"id":"Master:2"},"timeOffset":4},'
-            b'{"line":{"name":"21","direction":"U Niendorf Nord"},'
-            b'"station":{"id":"Master:1"},"timeOffset":1}'
-            b"]}"
+            b'{"line":{"name":"21","direction":"U Niendorf Nord"},"station":{"id":"Master:2"},"timeOffset":4},'
+            b'{"line":{"name":"21","direction":"U Niendorf Nord"},"station":{"id":"Master:1"},"timeOffset":1}]}'
         )
         client = GeofoxClient(
-            "https://example.test",
-            "user",
-            "secret",
-            min_request_interval=0,
+            "https://example.test", "user", "secret", min_request_interval=0,
             urlopen=lambda *_args, **_kwargs: response,
         )
         stations = (
-            Station(
-                "Weistritzstraße",
-                "Hamburg",
-                (Route("186", "S Othmarschen"),),
-                "Master:1",
-            ),
-            Station(
-                "Recknitzstraße",
-                "Hamburg",
-                (Route("21", "U Niendorf Nord"),),
-                "Master:2",
-            ),
+            Station("Weistritzstraße", "Hamburg", (Route("186", "S Othmarschen"),), "Master:1"),
+            Station("Recknitzstraße", "Hamburg", (Route("21", "U Niendorf Nord"),), "Master:2"),
         )
         now = datetime(2026, 7, 27, 12, 0, tzinfo=HAMBURG_TZ)
         result = client.departure_list(stations, now=now)
@@ -79,27 +142,15 @@ class GeofoxClientTest(unittest.TestCase):
 
     def test_offset_uses_real_minutes_across_daylight_saving_change(self) -> None:
         response = FakeResponse(
-            b'{"returnCode":"OK","departures":['
-            b'{"line":{"name":"21","direction":"U Niendorf Nord"},'
-            b'"timeOffset":60}]}'
+            b'{"returnCode":"OK","departures":[{"line":{"name":"21","direction":"U Niendorf Nord"},"timeOffset":60}]}'
         )
         client = GeofoxClient(
-            "https://example.test",
-            "user",
-            "secret",
-            min_request_interval=0,
+            "https://example.test", "user", "secret", min_request_interval=0,
             urlopen=lambda *_args, **_kwargs: response,
         )
-        station = Station(
-            "Recknitzstraße",
-            "Hamburg",
-            (Route("21", "U Niendorf Nord"),),
-            "Master:2",
-        )
+        station = Station("Recknitzstraße", "Hamburg", (Route("21", "U Niendorf Nord"),), "Master:2")
         now = datetime(2026, 3, 29, 1, 30, tzinfo=HAMBURG_TZ)
-
         result = client.departure_list((station,), now=now)
-
         self.assertEqual(result[0].departure_time.strftime("%H:%M %z"), "03:30 +0200")
 
 

--- a/tests/test_geofox.py
+++ b/tests/test_geofox.py
@@ -6,7 +6,13 @@ import urllib.error
 from datetime import datetime
 from unittest.mock import patch
 
-from hvv_display.geofox import HAMBURG_TZ, GeofoxClient, GeofoxError, normalize, route_matches
+from hvv_display.geofox import (
+    HAMBURG_TZ,
+    GeofoxClient,
+    GeofoxError,
+    normalize,
+    route_matches,
+)
 from hvv_display.models import Route, Station
 
 
@@ -47,11 +53,15 @@ class GeofoxClientTest(unittest.TestCase):
     def test_find_stations_returns_service_types_for_follow_up_flow(self) -> None:
         response = FakeResponse(
             b'{"returnCode":"OK","results":[{"type":"STATION","id":"Master:1",'
-            b'"name":"Jungfernstieg","city":"Hamburg","combinedName":"Hamburg, Jungfernstieg",'
+            b'"name":"Jungfernstieg","city":"Hamburg","combinedName":"Hamburg, '
+            b'Jungfernstieg",'
             b'"serviceTypes":["BUS","UBAHN","SBAHN"]}]}'
         )
         client = GeofoxClient(
-            "https://example.test", "user", "secret", min_request_interval=0,
+            "https://example.test",
+            "user",
+            "secret",
+            min_request_interval=0,
             urlopen=lambda *_args, **_kwargs: response,
         )
         result = client.find_stations("Jungfernstieg", "Hamburg")
@@ -63,7 +73,10 @@ class GeofoxClientTest(unittest.TestCase):
             b'{"returnCode":"ERROR_CN_TOO_MANY","errorDevInfo":"internal stack"}'
         )
         client = GeofoxClient(
-            "https://example.test", "user", "secret", min_request_interval=0,
+            "https://example.test",
+            "user",
+            "secret",
+            min_request_interval=0,
             urlopen=lambda *_args, **_kwargs: response,
         )
         with self.assertRaises(GeofoxError) as raised:
@@ -74,11 +87,15 @@ class GeofoxClientTest(unittest.TestCase):
 
     def test_error_text_is_sanitized_and_dev_info_is_hidden(self) -> None:
         response = FakeResponse(
-            b'{"returnCode":"ERROR_TEXT","errorText":"Ung\u00fcltig\\nbitte pr\u00fcfen",'
+            b'{"returnCode":"ERROR_TEXT","errorText":"Ung\u00fcltig\\n'
+            b'bitte pr\u00fcfen",'
             b'"errorDevInfo":"secret internal details"}'
         )
         client = GeofoxClient(
-            "https://example.test", "user", "secret", min_request_interval=0,
+            "https://example.test",
+            "user",
+            "secret",
+            min_request_interval=0,
             urlopen=lambda *_args, **_kwargs: response,
         )
         with self.assertRaises(GeofoxError) as raised:
@@ -91,7 +108,10 @@ class GeofoxClientTest(unittest.TestCase):
             "https://example.test", 429, "Too Many", {"Retry-After": "3"}, None
         )
         client = GeofoxClient(
-            "https://example.test", "user", "secret", min_request_interval=0,
+            "https://example.test",
+            "user",
+            "secret",
+            min_request_interval=0,
             urlopen=lambda *_args, **_kwargs: (_ for _ in ()).throw(error),
         )
         with self.assertRaises(GeofoxError) as raised:
@@ -103,15 +123,25 @@ class GeofoxClientTest(unittest.TestCase):
     def test_rate_limit_is_shared_across_client_instances(self) -> None:
         response = FakeResponse(b'{"returnCode":"OK","results":[]}')
         first = GeofoxClient(
-            "https://example.test", "user", "secret", min_request_interval=1.05,
+            "https://example.test",
+            "user",
+            "secret",
+            min_request_interval=1.05,
             urlopen=lambda *_args, **_kwargs: response,
         )
         second = GeofoxClient(
-            "https://example.test", "user", "secret", min_request_interval=1.05,
+            "https://example.test",
+            "user",
+            "secret",
+            min_request_interval=1.05,
             urlopen=lambda *_args, **_kwargs: response,
         )
-        with patch("hvv_display.geofox.time.sleep") as sleep, patch(
-            "hvv_display.geofox.time.monotonic", side_effect=[10.0, 10.0, 10.2, 11.25]
+        with (
+            patch("hvv_display.geofox.time.sleep") as sleep,
+            patch(
+                "hvv_display.geofox.time.monotonic",
+                side_effect=[10.0, 10.0, 10.2, 11.25],
+            ),
         ):
             first.find_stations("Test", "Hamburg")
             second.find_stations("Test", "Hamburg")
@@ -121,18 +151,34 @@ class GeofoxClientTest(unittest.TestCase):
     def test_departures_are_filtered_and_sorted(self) -> None:
         response = FakeResponse(
             b'{"returnCode":"OK","departures":['
-            b'{"line":{"name":"186","direction":"S Othmarschen"},"timeOffset":9,"delay":120},'
+            b'{"line":{"name":"186","direction":"S Othmarschen"},'
+            b'"timeOffset":9,"delay":120},'
             b'{"line":{"name":"1","direction":"Anderswo"},"timeOffset":2},'
-            b'{"line":{"name":"21","direction":"U Niendorf Nord"},"station":{"id":"Master:2"},"timeOffset":4},'
-            b'{"line":{"name":"21","direction":"U Niendorf Nord"},"station":{"id":"Master:1"},"timeOffset":1}]}'
+            b'{"line":{"name":"21","direction":"U Niendorf Nord"},'
+            b'"station":{"id":"Master:2"},"timeOffset":4},'
+            b'{"line":{"name":"21","direction":"U Niendorf Nord"},'
+            b'"station":{"id":"Master:1"},"timeOffset":1}]}'
         )
         client = GeofoxClient(
-            "https://example.test", "user", "secret", min_request_interval=0,
+            "https://example.test",
+            "user",
+            "secret",
+            min_request_interval=0,
             urlopen=lambda *_args, **_kwargs: response,
         )
         stations = (
-            Station("Weistritzstraße", "Hamburg", (Route("186", "S Othmarschen"),), "Master:1"),
-            Station("Recknitzstraße", "Hamburg", (Route("21", "U Niendorf Nord"),), "Master:2"),
+            Station(
+                "Weistritzstraße",
+                "Hamburg",
+                (Route("186", "S Othmarschen"),),
+                "Master:1",
+            ),
+            Station(
+                "Recknitzstraße",
+                "Hamburg",
+                (Route("21", "U Niendorf Nord"),),
+                "Master:2",
+            ),
         )
         now = datetime(2026, 7, 27, 12, 0, tzinfo=HAMBURG_TZ)
         result = client.departure_list(stations, now=now)
@@ -142,13 +188,19 @@ class GeofoxClientTest(unittest.TestCase):
 
     def test_offset_uses_real_minutes_across_daylight_saving_change(self) -> None:
         response = FakeResponse(
-            b'{"returnCode":"OK","departures":[{"line":{"name":"21","direction":"U Niendorf Nord"},"timeOffset":60}]}'
+            b'{"returnCode":"OK","departures":[{"line":{"name":"21",'
+            b'"direction":"U Niendorf Nord"},"timeOffset":60}]}'
         )
         client = GeofoxClient(
-            "https://example.test", "user", "secret", min_request_interval=0,
+            "https://example.test",
+            "user",
+            "secret",
+            min_request_interval=0,
             urlopen=lambda *_args, **_kwargs: response,
         )
-        station = Station("Recknitzstraße", "Hamburg", (Route("21", "U Niendorf Nord"),), "Master:2")
+        station = Station(
+            "Recknitzstraße", "Hamburg", (Route("21", "U Niendorf Nord"),), "Master:2"
+        )
         now = datetime(2026, 3, 29, 1, 30, tzinfo=HAMBURG_TZ)
         result = client.departure_list((station,), now=now)
         self.assertEqual(result[0].departure_time.strftime("%H:%M %z"), "03:30 +0200")

--- a/tests/test_geofox_errors.py
+++ b/tests/test_geofox_errors.py
@@ -30,6 +30,10 @@ class FakeResponse:
 
 
 class GeofoxErrorTest(unittest.TestCase):
+    def setUp(self) -> None:
+        GeofoxClient._global_last_request_at = 0.0
+        GeofoxClient._global_retry_until = 0.0
+
     def client_for(self, response: bytes) -> GeofoxClient:
         return GeofoxClient(
             "https://example.test",
@@ -73,11 +77,13 @@ class GeofoxErrorTest(unittest.TestCase):
             urlopen=lambda *_args, **_kwargs: (_ for _ in ()).throw(error),
         )
 
-        with self.assertRaisesRegex(GeofoxError, "Zugangsdaten wurden abgelehnt"):
+        with self.assertRaisesRegex(
+            GeofoxError, "Zugangsdaten oder Berechtigungen wurden abgelehnt"
+        ):
             client._post("departureList", {})
 
     def test_http_rate_limit_and_server_errors_have_safe_messages(self) -> None:
-        cases = ((429, "Anfragelimit"), (503, "HTTP 503"))
+        cases = ((429, "Anfragelimit"), (503, "Geofox ist aktuell nicht erreichbar"))
         for code, message in cases:
             with self.subTest(code=code):
                 error = urllib.error.HTTPError(
@@ -157,14 +163,14 @@ class GeofoxErrorTest(unittest.TestCase):
     def test_rate_limit_waits_only_for_remaining_interval(self) -> None:
         client = self.client_for(b'{"returnCode":"OK"}')
         client.min_request_interval = 1.0
-        client._last_request_at = 10.0
+        GeofoxClient._global_last_request_at = 10.0
         with (
             patch("hvv_display.geofox.time.monotonic", side_effect=[10.25, 11.25]),
             patch("hvv_display.geofox.time.sleep") as sleep,
         ):
             client._wait_for_rate_limit()
         sleep.assert_called_once_with(0.75)
-        self.assertEqual(client._last_request_at, 11.25)
+        self.assertEqual(GeofoxClient._global_last_request_at, 11.25)
 
     def test_api_error_uses_user_message(self) -> None:
         client = self.client_for(
@@ -267,6 +273,7 @@ class GeofoxErrorTest(unittest.TestCase):
                 "city": "Hamburg",
                 "id": "Master:1",
                 "type": "STATION",
+                "serviceTypes": [],
             },
         )
 

--- a/tests/test_geofox_errors.py
+++ b/tests/test_geofox_errors.py
@@ -103,6 +103,24 @@ class GeofoxErrorTest(unittest.TestCase):
                 with self.assertRaisesRegex(GeofoxError, message):
                     client._post("departureList", {})
 
+    def test_unexpected_http_status_has_a_safe_message(self) -> None:
+        error = urllib.error.HTTPError(
+            "https://example.test/departureList",
+            400,
+            "Bad Request",
+            {},
+            io.BytesIO(b"backend details"),
+        )
+        client = GeofoxClient(
+            "https://example.test",
+            "user",
+            "secret",
+            min_request_interval=0,
+            urlopen=lambda *_args, **_kwargs: (_ for _ in ()).throw(error),
+        )
+        with self.assertRaisesRegex(GeofoxError, "HTTP 400"):
+            client._post("departureList", {})
+
     def test_rate_limit_exposes_bounded_retry_after(self) -> None:
         error = urllib.error.HTTPError(
             "https://example.test/departureList",
@@ -259,6 +277,11 @@ class GeofoxErrorTest(unittest.TestCase):
         )
         with self.assertRaisesRegex(GeofoxError, "nicht gefunden"):
             client.find_station("Markt", "Hamburg")
+
+    def test_station_search_rejects_invalid_result_collection(self) -> None:
+        client = self.client_for(b'{"returnCode":"OK","results":"invalid"}')
+        with self.assertRaisesRegex(GeofoxError, "gültige Haltestellenliste"):
+            client.find_stations("Markt", "Hamburg")
 
     def test_station_search_uses_combined_name_and_fallback_values(self) -> None:
         client = self.client_for(

--- a/tests/test_station_management.py
+++ b/tests/test_station_management.py
@@ -1,0 +1,88 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from hvv_display.geofox import GeofoxError
+from hvv_display.web import WebApplication
+
+
+class StationManagementTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.directory = tempfile.TemporaryDirectory()
+        root = Path(self.directory.name)
+        self.config = root / "config.json"
+        self.config.write_text(
+            (Path(__file__).parents[1] / "config.example.json").read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
+        self.credentials = root / "credentials.env"
+        self.credentials.write_text("GEOFOX_USER=test\nGEOFOX_PASSWORD=secret\n", encoding="utf-8")
+        self.app = WebApplication(self.config, self.credentials, root / "stations.json")
+
+    def tearDown(self) -> None:
+        self.directory.cleanup()
+
+    def test_settings_uses_automatic_station_search_and_readonly_geofox_id(self) -> None:
+        page = self.app.settings().decode("utf-8")
+        self.assertIn("Vorschläge erscheinen automatisch", page)
+        self.assertIn('data-station-field="id"', page)
+        self.assertIn("readonly", page)
+        self.assertIn("scheduleStationSearch", page)
+        self.assertIn("Geofox wird abgefragt", page)
+        self.assertIn("Richtung oder Zielstation?", page)
+
+    def test_station_search_validates_lengths_before_geofox_request(self) -> None:
+        with self.assertRaisesRegex(ValueError, "zu lang"):
+            self.app.station_suggestions("x" * 121, "Hamburg")
+        with self.assertRaisesRegex(ValueError, "mindestens zwei"):
+            self.app.station_suggestions("x", "Hamburg")
+
+    def test_station_config_is_revalidated_and_enriched_before_save(self) -> None:
+        raw = json.loads(self.config.read_text(encoding="utf-8"))
+        raw["stations"] = [{
+            "name": "Jungfernstieg",
+            "city": "Hamburg",
+            "id": "Master:1",
+            "label": "J",
+            "routes": [{"line": "5", "destination": "Hauptbahnhof"}],
+        }]
+        matches = [{
+            "name": "Jungfernstieg",
+            "city": "Hamburg",
+            "id": "Master:1",
+            "combinedName": "Hamburg, Jungfernstieg",
+            "serviceTypes": ["BUS", "UBAHN", "SBAHN"],
+        }]
+        with patch.object(self.app, "_client") as client:
+            client.return_value.find_stations.return_value = matches
+            validated = self.app.validate_station_config(raw, user="test", password="secret")
+        self.assertEqual(validated["stations"][0]["serviceTypes"], ["BUS", "UBAHN", "SBAHN"])
+        self.assertEqual(validated["stations"][0]["id"], "Master:1")
+
+    def test_station_config_rejects_unselected_or_stale_station(self) -> None:
+        raw = json.loads(self.config.read_text(encoding="utf-8"))
+        raw["stations"][0].pop("id", None)
+        with patch.object(self.app, "_client"):
+            with self.assertRaisesRegex(ValueError, "Geofox-Vorschlag auswählen"):
+                self.app.validate_station_config(raw, user="test", password="secret")
+
+        raw = json.loads(self.config.read_text(encoding="utf-8"))
+        with patch.object(self.app, "_client") as client:
+            client.return_value.find_stations.return_value = []
+            with self.assertRaisesRegex(ValueError, "findet die ausgewählte Haltestelle nicht mehr"):
+                self.app.validate_station_config(raw, user="test", password="secret")
+
+    def test_geofox_error_is_not_treated_as_invalid_station(self) -> None:
+        raw = json.loads(self.config.read_text(encoding="utf-8"))
+        with patch.object(self.app, "_client") as client:
+            client.return_value.find_stations.side_effect = GeofoxError(
+                "Geofox ist aktuell nicht erreichbar.", kind="temporary", http_status=503
+            )
+            with self.assertRaises(GeofoxError):
+                self.app.validate_station_config(raw, user="test", password="secret")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_station_management.py
+++ b/tests/test_station_management.py
@@ -14,17 +14,23 @@ class StationManagementTest(unittest.TestCase):
         root = Path(self.directory.name)
         self.config = root / "config.json"
         self.config.write_text(
-            (Path(__file__).parents[1] / "config.example.json").read_text(encoding="utf-8"),
+            (Path(__file__).parents[1] / "config.example.json").read_text(
+                encoding="utf-8"
+            ),
             encoding="utf-8",
         )
         self.credentials = root / "credentials.env"
-        self.credentials.write_text("GEOFOX_USER=test\nGEOFOX_PASSWORD=secret\n", encoding="utf-8")
+        self.credentials.write_text(
+            "GEOFOX_USER=test\nGEOFOX_PASSWORD=secret\n", encoding="utf-8"
+        )
         self.app = WebApplication(self.config, self.credentials, root / "stations.json")
 
     def tearDown(self) -> None:
         self.directory.cleanup()
 
-    def test_settings_uses_automatic_station_search_and_readonly_geofox_id(self) -> None:
+    def test_settings_uses_automatic_station_search_and_readonly_geofox_id(
+        self,
+    ) -> None:
         page = self.app.settings().decode("utf-8")
         self.assertIn("Vorschläge erscheinen automatisch", page)
         self.assertIn('data-station-field="id"', page)
@@ -41,24 +47,34 @@ class StationManagementTest(unittest.TestCase):
 
     def test_station_config_is_revalidated_and_enriched_before_save(self) -> None:
         raw = json.loads(self.config.read_text(encoding="utf-8"))
-        raw["stations"] = [{
-            "name": "Jungfernstieg",
-            "city": "Hamburg",
-            "id": "Master:1",
-            "label": "J",
-            "routes": [{"line": "5", "destination": "Hauptbahnhof"}],
-        }]
-        matches = [{
-            "name": "Jungfernstieg",
-            "city": "Hamburg",
-            "id": "Master:1",
-            "combinedName": "Hamburg, Jungfernstieg",
-            "serviceTypes": ["BUS", "UBAHN", "SBAHN"],
-        }]
+        raw["stations"] = [
+            {
+                "name": "Jungfernstieg",
+                "city": "Hamburg",
+                "id": "Master:1",
+                "label": "J",
+                "routes": [{"line": "5", "destination": "Hauptbahnhof"}],
+            }
+        ]
+        matches = [
+            {
+                "name": "Jungfernstieg",
+                "city": "Hamburg",
+                "id": "Master:1",
+                "combinedName": "Hamburg, Jungfernstieg",
+                "serviceTypes": ["BUS", "UBAHN", "SBAHN"],
+            }
+        ]
         with patch.object(self.app, "_client") as client:
             client.return_value.find_stations.return_value = matches
-            validated = self.app.validate_station_config(raw, user="test", password="secret")
-        self.assertEqual(validated["stations"][0]["serviceTypes"], ["BUS", "UBAHN", "SBAHN"])
+            validated = self.app.validate_station_config(
+                raw,
+                user="test",
+                password="secret",  # noqa: S106
+            )
+        self.assertEqual(
+            validated["stations"][0]["serviceTypes"], ["BUS", "UBAHN", "SBAHN"]
+        )
         self.assertEqual(validated["stations"][0]["id"], "Master:1")
 
     def test_station_config_rejects_unselected_or_stale_station(self) -> None:
@@ -66,22 +82,38 @@ class StationManagementTest(unittest.TestCase):
         raw["stations"][0].pop("id", None)
         with patch.object(self.app, "_client"):
             with self.assertRaisesRegex(ValueError, "Geofox-Vorschlag auswählen"):
-                self.app.validate_station_config(raw, user="test", password="secret")
+                self.app.validate_station_config(
+                    raw,
+                    user="test",
+                    password="secret",  # noqa: S106
+                )
 
         raw = json.loads(self.config.read_text(encoding="utf-8"))
         with patch.object(self.app, "_client") as client:
             client.return_value.find_stations.return_value = []
-            with self.assertRaisesRegex(ValueError, "findet die ausgewählte Haltestelle nicht mehr"):
-                self.app.validate_station_config(raw, user="test", password="secret")
+            with self.assertRaisesRegex(
+                ValueError, "findet die ausgewählte Haltestelle nicht mehr"
+            ):
+                self.app.validate_station_config(
+                    raw,
+                    user="test",
+                    password="secret",  # noqa: S106
+                )
 
     def test_geofox_error_is_not_treated_as_invalid_station(self) -> None:
         raw = json.loads(self.config.read_text(encoding="utf-8"))
         with patch.object(self.app, "_client") as client:
             client.return_value.find_stations.side_effect = GeofoxError(
-                "Geofox ist aktuell nicht erreichbar.", kind="temporary", http_status=503
+                "Geofox ist aktuell nicht erreichbar.",
+                kind="temporary",
+                http_status=503,
             )
             with self.assertRaises(GeofoxError):
-                self.app.validate_station_config(raw, user="test", password="secret")
+                self.app.validate_station_config(
+                    raw,
+                    user="test",
+                    password="secret",  # noqa: S106
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #43

## Inhalt
- Haltestellen-Autocomplete ab 2 Zeichen mit Debounce, Loader und Schutz vor stale Responses
- Auswahl eines Geofox-Treffers übernimmt offiziellen Namen, Stadt, ID und `serviceTypes`
- technische Geofox-ID ist nicht mehr manuell editierbar
- Änderung von Name/Stadt invalidiert die bisherige Geofox-Auswahl
- serverseitige Revalidierung aller Haltestellen vor dem Speichern; keine partielle Config-Änderung bei Fehlern
- zentrale/prozessweite Geofox-Serialisierung mit mindestens 1,05 s Abstand, auch über mehrere Client-Instanzen hinweg
- `429 Retry-After`, HTTP-Fehler und Geofox-`returnCode` werden differenziert behandelt
- `errorDevInfo` wird nicht an die UI durchgereicht
- übergroße POST-Bodies werden mit 413 abgelehnt statt abgeschnitten
- Input-Limits und Security-Header ergänzt
- Hilfe zu „Richtung“ vs. „Zu Zielstation“ bereits im Haltestellen-Setup
- neue Unit-/Integrationstests für Rate-Limit, Fehlerkanäle, Metadaten und Revalidierung

## Abgrenzung
Linienauswahl, Verkehrsmittel und Richtungs-/Zielstationslogik bleiben bewusst in #44/#42.

## Tests
CI soll Unit-, Lint- und Security-Checks ausführen; eventuelle Befunde werden in diesem Branch korrigiert.