### PR TITLE
feat: offer multimodal lines per station

### DIFF
--- a/hvv_display/config.py
+++ b/hvv_display/config.py
@@ -173,12 +173,7 @@ def load_config(path: str | Path) -> AppConfig:
                 f"stations[{index}].label muss zwischen 1 und 3 Zeichen lang sein"
             )
         routes = tuple(
-            Route(
-                line=str(_required(route, "line", f"stations[{index}].routes")),
-                destination=str(
-                    _required(route, "destination", f"stations[{index}].routes")
-                ),
-            )
+            _route_from_raw(route, f"stations[{index}].routes")
             for route in _required(station_raw, "routes", f"stations[{index}]")
         )
         if not routes:
@@ -203,4 +198,24 @@ def load_config(path: str | Path) -> AppConfig:
         display=display,
         night_shutdown=night_shutdown,
         stations=tuple(stations),
+    )
+
+
+def _route_from_raw(route: Any, section: str) -> Route:
+    if not isinstance(route, dict):
+        raise ConfigError(f"{section} muss Objekte enthalten")
+    line = str(_required(route, "line", section)).strip()
+    if "destination" not in route and "line_id" not in route:
+        _required(route, "destination", section)
+    line_id = route.get("line_id")
+    line_id = str(line_id).strip() if line_id is not None else None
+    destination = str(route.get("destination", "")).strip()
+    if not line or (not destination and not line_id):
+        raise ConfigError(f"{section}.destination oder line_id muss gesetzt sein")
+    product = route.get("product")
+    return Route(
+        line=line,
+        destination=destination,
+        line_id=line_id or None,
+        product=str(product).strip() if product is not None else None,
     )

--- a/hvv_display/geofox.py
+++ b/hvv_display/geofox.py
@@ -19,12 +19,33 @@ from typing import Any
 from urllib.parse import urlsplit
 from zoneinfo import ZoneInfo
 
-from .models import Departure, Route, Station
+from .models import Departure, LineOption, Route, Station
 
 LOG = logging.getLogger(__name__)
 HAMBURG_TZ = ZoneInfo("Europe/Berlin")
 MAX_RESPONSE_BYTES = 1024 * 1024
 MAX_RETRY_AFTER_SECONDS = 3600
+MAX_LINE_OPTIONS = 200
+_VEHICLE_LABELS = {
+    "UBAHN": "U-Bahn",
+    "SBAHN": "S-Bahn",
+    "ABAHN": "A-Bahn",
+    "AKN": "AKN",
+    "RBAHN": "Regionalbahn",
+    "FBAHN": "Fernbahn",
+    "ZUG": "Bahn",
+    "TRAIN": "Bahn",
+    "BUS": "Bus",
+    "STADTBUS": "Stadtbus",
+    "REGIONALBUS": "Regionalbus",
+    "METROBUS": "MetroBus",
+    "SCHNELLBUS": "SchnellBus",
+    "NACHTBUS": "NachtBus",
+    "XPRESSBUS": "XpressBus",
+    "AST": "Anruf-Sammeltaxi",
+    "SCHIFF": "Fähre",
+    "FAEHRE": "Fähre",
+}
 
 
 class GeofoxError(RuntimeError):
@@ -81,7 +102,9 @@ def route_matches(line_name: str, direction: str, routes: tuple[Route, ...]) -> 
     normalized_direction = normalize(direction)
     for route in routes:
         expected = normalize(route.destination)
-        if normalize(line_name) == normalize(route.line) and (
+        if normalize(line_name) != normalize(route.line):
+            continue
+        if not expected or (
             expected in normalized_direction or normalized_direction in expected
         ):
             return True
@@ -112,6 +135,81 @@ def _safe_external_text(value: Any, limit: int = 160) -> str:
     return "".join(
         character if character.isprintable() else " " for character in str(value)
     ).strip()[:limit]
+
+
+def _vehicle_code(value: Any) -> str:
+    if isinstance(value, dict):
+        value = (
+            value.get("simpleType")
+            or value.get("vehicleType")
+            or value.get("shortInfo")
+            or ""
+        )
+    return str(value or "").strip().upper().replace("-", "_").replace(" ", "_")
+
+
+def _safe_vehicle_product(value: Any) -> str:
+    code = _vehicle_code(value).replace("_", "")
+    return code if code in _VEHICLE_LABELS else "UNKNOWN"
+
+
+def vehicle_type_label(value: Any) -> str:
+    code = _safe_vehicle_product(value)
+    return _VEHICLE_LABELS.get(code, "Unbekanntes Verkehrsmittel")
+
+
+def line_options_for_station(
+    lines: Any, station_id: str
+) -> tuple[LineOption, ...]:
+    options: list[LineOption] = []
+    seen: set[str] = set()
+    for raw_line in lines if isinstance(lines, list) else []:
+        if not isinstance(raw_line, dict) or raw_line.get("exists") is False:
+            continue
+        line_id = _safe_external_text(raw_line.get("id"), 160)
+        line_name = _safe_external_text(raw_line.get("name"), 80)
+        if not line_id or not line_name or line_id in seen:
+            continue
+        sublines = raw_line.get("sublines")
+        if not isinstance(sublines, list):
+            continue
+        for subline in sublines:
+            if not isinstance(subline, dict):
+                continue
+            sequence = subline.get("stationSequence")
+            if not isinstance(sequence, list) or not any(
+                isinstance(stop, dict) and str(stop.get("id", "")) == station_id
+                for stop in sequence
+            ):
+                continue
+            raw_product = _vehicle_code(
+                subline.get("vehicleType") or raw_line.get("type")
+            )
+            product = _safe_vehicle_product(raw_product) if raw_product else "UNKNOWN"
+            if product == "UNKNOWN":
+                LOG.warning("Linie %s hat kein bekanntes Verkehrsmittel", line_name)
+            options.append(
+                LineOption(
+                    line_id=line_id,
+                    name=line_name,
+                    product=product,
+                    product_label=vehicle_type_label(product),
+                    carrier=_safe_external_text(
+                        raw_line.get("carrierNameShort")
+                        or raw_line.get("carrierNameLong"),
+                        80,
+                    ),
+                )
+            )
+            seen.add(line_id)
+            break
+        if len(options) >= MAX_LINE_OPTIONS:
+            LOG.warning(
+                "Linienliste für Haltestelle auf %d Einträge begrenzt",
+                MAX_LINE_OPTIONS,
+            )
+            break
+    return tuple(options)
 
 
 def _return_code_error(result: dict[str, Any]) -> GeofoxError:
@@ -347,6 +445,27 @@ class GeofoxClient:
             for station in matches[:10]
         ]
 
+    def list_lines(self) -> list[dict[str, Any]]:
+        result = self._post(
+            "listLines",
+            {
+                "language": "de",
+                "version": self.version,
+                "dataReleaseID": "",
+                "modificationTypes": ["MAIN", "SEQUENCE"],
+                "withSublines": True,
+            },
+        )
+        lines = result.get("lines")
+        if lines is None:
+            lines = []
+        if not isinstance(lines, list):
+            raise GeofoxError("Geofox liefert keine gültige Linienliste")
+        return lines
+
+    def line_options(self, station_id: str) -> tuple[LineOption, ...]:
+        return line_options_for_station(self.list_lines(), station_id)
+
     def departure_list(
         self,
         stations: tuple[Station, ...],
@@ -367,9 +486,19 @@ class GeofoxClient:
             },
             "maxList": max_list,
             "maxTimeOffset": max_time_offset,
-            "serviceTypes": ["BUS"],
             "useRealtime": True,
         }
+        filters = [
+            {
+                "serviceID": route.line_id,
+                "serviceName": route.line,
+            }
+            for station in stations
+            for route in station.routes
+            if route.line_id
+        ]
+        if filters:
+            payload["filter"] = filters
         if len(station_names) == 1:
             payload["station"] = station_names[0]
         else:
@@ -393,6 +522,9 @@ class GeofoxClient:
                 continue
             line_name = str(line.get("name", ""))
             direction = str(line.get("direction", ""))
+            product = _safe_vehicle_product(
+                line.get("type") or line.get("vehicleType")
+            )
             response_station = raw.get("station") or {}
             response_station_id = (
                 response_station.get("id")
@@ -436,6 +568,7 @@ class GeofoxClient:
                         if len(matching_stations) == 1
                         else ""
                     ),
+                    product=product or None,
                 )
             )
         return sorted(departures, key=lambda departure: departure.departure_time)

--- a/hvv_display/models.py
+++ b/hvv_display/models.py
@@ -8,6 +8,17 @@ from datetime import datetime
 class Route:
     line: str
     destination: str
+    line_id: str | None = None
+    product: str | None = None
+
+
+@dataclass(frozen=True)
+class LineOption:
+    line_id: str
+    name: str
+    product: str
+    product_label: str
+    carrier: str = ""
 
 
 @dataclass(frozen=True)

--- a/hvv_display/web.py
+++ b/hvv_display/web.py
@@ -24,7 +24,12 @@ from urllib.parse import parse_qs, urlsplit
 
 from .config import ConfigError, load_config
 from .credentials import load_credentials
-from .geofox import HAMBURG_TZ, GeofoxClient, GeofoxError
+from .geofox import (
+    HAMBURG_TZ,
+    GeofoxClient,
+    GeofoxError,
+    line_options_for_station,
+)
 from .render import get_line_style, line_style_css
 from .stations import resolve_stations
 
@@ -196,6 +201,7 @@ class WebApplication:
             os.environ.get("HVV_WEB_ENV_FILE", "var/web.env")
         )
         self.csrf_token = secrets.token_urlsafe(32)
+        self._line_catalog: list[dict[str, Any]] | None = None
 
     def authorize(self, headers: Any) -> bool:
         if self.access_token is None:
@@ -289,6 +295,27 @@ class WebApplication:
             raise ValueError("Suchbegriff oder Stadt ist zu lang")
         return self._client().find_stations(query, city)
 
+    def line_suggestions(self, station_id: str) -> list[dict[str, str]]:
+        station_id = station_id.strip()
+        if not station_id or len(station_id) > MAX_STATION_ID_LENGTH:
+            raise ValueError("Geofox-ID ist ungültig")
+        if any(character in station_id for character in ("\r", "\n", "\x00")):
+            raise ValueError("Geofox-ID ist ungültig")
+        client = self._client()
+        if self._line_catalog is None:
+            self._line_catalog = client.list_lines()
+        options = line_options_for_station(self._line_catalog, station_id)
+        return [
+            {
+                "id": option.line_id,
+                "name": option.name,
+                "product": option.product,
+                "productLabel": option.product_label,
+                "carrier": option.carrier,
+            }
+            for option in options
+        ]
+
     def validate_station_config(
         self, raw_config: dict[str, Any], *, user: str, password: str
     ) -> dict[str, Any]:
@@ -324,6 +351,39 @@ class WebApplication:
             station["city"] = match["city"]
             station["id"] = match["id"]
             station["serviceTypes"] = match.get("serviceTypes", [])
+            routes = station.get("routes")
+            if not isinstance(routes, list) or not routes:
+                raise ValueError(
+                    f"Haltestelle {index + 1}: Mindestens eine Linie auswählen"
+                )
+            line_ids = {
+                str(route.get("line_id")).strip()
+                for route in routes
+                if isinstance(route, dict) and route.get("line_id")
+            }
+            if line_ids:
+                if self._line_catalog is None:
+                    self._line_catalog = client.list_lines()
+                available = {
+                    option.line_id: option
+                    for option in line_options_for_station(
+                        self._line_catalog, station["id"]
+                    )
+                }
+                for route in routes:
+                    if not isinstance(route, dict):
+                        raise ValueError(f"Haltestelle {index + 1}: Linie ist ungültig")
+                    line_id = str(route.get("line_id") or "").strip()
+                    if not line_id:
+                        continue
+                    option = available.get(line_id)
+                    if option is None:
+                        raise ValueError(
+                            f"Haltestelle {index + 1}: Linie ist an dieser Haltestelle nicht verfügbar"
+                        )
+                    route["line"] = option.name
+                    route["product"] = option.product
+                    route["destination"] = str(route.get("destination") or "").strip()
         return raw_config
 
     def dashboard(self) -> bytes:
@@ -397,8 +457,20 @@ class WebApplication:
             return f'<div class="setting"><label for="{path}">{path}</label><div class="control-row">{control}<button type="button" class="reset" onclick="resetField(this)">Auf Standard zurücksetzen</button></div><div class="subtle">{descriptions[path]}</div></div>'
 
         def station_card(station: dict[str, Any], index: int) -> str:
+            selected_lines = [
+                {
+                    "id": str(route.get("line_id") or ""),
+                    "name": str(route.get("line") or ""),
+                    "product": str(route.get("product") or ""),
+                }
+                for route in station.get("routes", [])
+                if isinstance(route, dict) and route.get("line_id")
+            ]
+            selected_lines_json = html.escape(
+                json.dumps(selected_lines, ensure_ascii=False), quote=True
+            )
             routes = "".join(
-                f'<div class="route-row"><input data-route="line" value="{html.escape(str(route.get("line", "")), quote=True)}" placeholder="Linie" aria-label="Linie"><input data-route="destination" value="{html.escape(str(route.get("destination", "")), quote=True)}" placeholder="Ziel" aria-label="Ziel"><button type="button" class="reset" onclick="this.parentElement.remove()">Route entfernen</button></div>'
+                f'<div class="route-row"><input data-route="line" value="{html.escape(str(route.get("line", "")), quote=True)}" placeholder="Linie" aria-label="Linie"><input data-route="destination" value="{html.escape(str(route.get("destination", "")), quote=True)}" placeholder="Ziel" aria-label="Ziel"><input type="hidden" data-route-line-id value="{html.escape(str(route.get("line_id") or ""), quote=True)}"><input type="hidden" data-route-product value="{html.escape(str(route.get("product") or ""), quote=True)}"><button type="button" class="reset" onclick="this.parentElement.remove()">Route entfernen</button></div>'
                 for route in station.get("routes", [])
             )
             valid = bool(station.get("id"))
@@ -411,7 +483,7 @@ class WebApplication:
 <input type="hidden" data-station-field="serviceTypes" value="{html.escape(service_types, quote=True)}">
 <div class="station-search"><select data-station-results aria-label="Geofox-Haltestellenvorschläge"><option value="">Treffer auswählen …</option></select><span class="subtle" data-search-message>{'<span class="ok">✓ Geofox-Haltestelle ausgewählt</span>' if valid else "Bitte Haltestelle aus einem Geofox-Vorschlag auswählen."}</span></div>
 <details class="help-box"><summary>Richtung oder Zielstation?</summary><p><strong>Richtung</strong> wählt später den Linienast; auch Fahrten, die vorher enden, können angezeigt werden. <strong>Zu Zielstation</strong> zeigt nur Fahrten, die diese Station tatsächlich erreichen. Beispiel: U2 Richtung Niendorf Nord kann einen Kurzläufer nach Niendorf Markt enthalten; „Zu Zielstation Niendorf Nord“ nicht.</p></details>
-<h4>Linien und Ziele</h4><div data-routes>{routes}</div><button type="button" onclick="addRoute(this)">Route hinzufügen</button></article>'''
+<h4>Linien und Ziele</h4><div data-line-picker data-selected-lines="{selected_lines_json}"><div class="control-row"><button type="button" data-load-lines onclick="loadLines(this)" {"disabled" if not valid else ""}>Verfügbare Linien laden</button><span class="subtle" data-lines-message>{'Mehrere Verkehrsmittel werden gemeinsam angeboten.' if valid else 'Nach der Haltestellenauswahl hier die verfügbaren Linien laden.'}</span></div><div data-line-options role="group" aria-label="Verfügbare Linien"></div></div><div data-routes>{routes}</div><details><summary>Legacy-Konfiguration manuell bearbeiten</summary><p class="subtle">Bestehende Bus-Konfigurationen bleiben kompatibel. Für neue Haltestellen bitte die Geofox-Linienauswahl verwenden.</p><button type="button" onclick="addRoute(this)">Route hinzufügen</button></details></article>'''
 
         stations = "".join(
             station_card(station, index)
@@ -427,16 +499,19 @@ class WebApplication:
 <section class="card"><div class="station-heading"><div><h2>Haltestellen und Linien</h2><p class="subtle">Haltestelle eintippen, Geofox-Vorschlag auswählen; Name, Stadt und ID werden automatisch übernommen.</p></div><button type="button" onclick="addStation()">Haltestelle hinzufügen</button></div><div id="stations">{stations}</div></section>
 <textarea id="config_json" name="config_json" hidden>{raw}</textarea><input type="hidden" name="csrf_token" value="{html.escape(self.csrf_token, quote=True)}"><p><button id="save-settings" type="submit">Speichern und prüfen</button></p></form>
 <script>
-let requestSequence=0; let debounceTimers=new WeakMap(); let controllers=new WeakMap();
+let requestSequence=0; let debounceTimers=new WeakMap(); let controllers=new WeakMap(); let lineControllers=new WeakMap(); let lineSequences=new WeakMap();
 function resetField(button){{const control=button.parentElement.querySelector('[data-path]');control.value=control.dataset.default}}
-function addRoute(button){{const row=document.createElement('div');row.className='route-row';row.innerHTML='<input data-route="line" placeholder="Linie" aria-label="Linie"><input data-route="destination" placeholder="Ziel" aria-label="Ziel"><button type="button" class="reset" onclick="this.parentElement.remove()">Route entfernen</button>';button.previousElementSibling.appendChild(row)}}
-function invalidateStation(card){{card.dataset.valid='false';card.querySelector('[data-station-field="id"]').value='';card.querySelector('[data-station-field="serviceTypes"]').value='[]';card.querySelector('[data-search-message]').textContent='Bitte Haltestelle aus einem Geofox-Vorschlag auswählen.'}}
+function addRoute(button){{const row=document.createElement('div');row.className='route-row';row.innerHTML='<input data-route="line" placeholder="Linie" aria-label="Linie"><input data-route="destination" placeholder="Ziel" aria-label="Ziel"><input type="hidden" data-route-line-id><input type="hidden" data-route-product><button type="button" class="reset" onclick="this.parentElement.remove()">Route entfernen</button>';button.closest('[data-station]').querySelector('[data-routes]').appendChild(row)}}
+function invalidateStation(card){{card.dataset.valid='false';card.querySelector('[data-station-field="id"]').value='';card.querySelector('[data-station-field="serviceTypes"]').value='[]';card.querySelector('[data-search-message]').textContent='Bitte Haltestelle aus einem Geofox-Vorschlag auswählen.';card.querySelector('[data-line-options]').replaceChildren();card.querySelector('[data-lines-message]').textContent='Nach der Haltestellenauswahl hier die verfügbaren Linien laden.';card.querySelector('[data-load-lines]').disabled=true;lineControllers.get(card)?.abort();lineSequences.set(card,(lineSequences.get(card)||0)+1);card.querySelector('[data-routes]').replaceChildren();card.querySelector('[data-line-picker]').dataset.selectedLines='[]'}}
 function bindStation(card){{const name=card.querySelector('[data-station-field="name"]');const city=card.querySelector('[data-station-field="city"]');[name,city].forEach(input=>input.addEventListener('input',()=>{{invalidateStation(card);scheduleStationSearch(card)}}));}}
 function scheduleStationSearch(card){{clearTimeout(debounceTimers.get(card));const query=card.querySelector('[data-station-field="name"]').value.trim();if(query.length<2) return;debounceTimers.set(card,setTimeout(()=>searchStation(card),350))}}
 async function searchStation(card){{const query=card.querySelector('[data-station-field="name"]').value.trim();const city=card.querySelector('[data-station-field="city"]').value.trim();const select=card.querySelector('[data-station-results]');const message=card.querySelector('[data-search-message]');const sequence=++requestSequence;controllers.get(card)?.abort();const controller=new AbortController();controllers.set(card,controller);select.disabled=true;message.innerHTML='<span class="spinner" aria-hidden="true"></span> Geofox wird abgefragt …';try{{const response=await fetch('/api/stations?q='+encodeURIComponent(query)+'&city='+encodeURIComponent(city),{{signal:controller.signal}});const data=await response.json();if(sequence!==requestSequence)return;if(!response.ok)throw new Error(data.error||'Geofox-Suche fehlgeschlagen');select.replaceChildren(new Option('Treffer auswählen …',''));data.stations.forEach(station=>{{const option=new Option(station.combinedName,JSON.stringify(station));select.appendChild(option)}});message.textContent=data.stations.length?'Bitte passenden Treffer auswählen.':'Keine passende Haltestelle gefunden.'}}catch(error){{if(error.name!=='AbortError')message.textContent=error.message}}finally{{if(sequence===requestSequence)select.disabled=false}}}}
-function applyStation(select){{if(!select.value)return;const station=JSON.parse(select.value);const card=select.closest('[data-station]');card.querySelector('[data-station-field="name"]').value=station.name;card.querySelector('[data-station-field="city"]').value=station.city;card.querySelector('[data-station-field="id"]').value=station.id;card.querySelector('[data-station-field="serviceTypes"]').value=JSON.stringify(station.serviceTypes||[]);card.dataset.valid='true';card.querySelector('[data-search-message]').innerHTML='<span class="ok">✓ Geofox-Haltestelle ausgewählt</span>'}}
-function addStation(){{const first=document.querySelector('[data-station]');const clone=first.cloneNode(true);clone.querySelectorAll('input').forEach(input=>input.value=input.dataset.stationField==='city'?'Hamburg':(input.dataset.stationField==='serviceTypes'?'[]':''));clone.querySelector('[data-routes]').innerHTML='';clone.querySelector('[data-station-results]').replaceChildren(new Option('Treffer auswählen …',''));invalidateStation(clone);document.getElementById('stations').appendChild(clone);bindStation(clone)}}
-function prepareConfig(){{const invalid=[...document.querySelectorAll('[data-station]')].find(card=>card.dataset.valid!=='true');if(invalid){{invalid.querySelector('[data-search-message]').innerHTML='<span class="error">Bitte zuerst einen gültigen Geofox-Vorschlag auswählen.</span>';invalid.scrollIntoView({{behavior:'smooth',block:'center'}});return false}}const config=JSON.parse(document.getElementById('config_json').value);document.querySelectorAll('[data-path]').forEach(control=>{{const [section,key]=control.dataset.path.split('.');config[section][key]=control.dataset.type==='bool'?control.value==='true':(control.type==='number'?Number(control.value):control.value)}});config.stations=[...document.querySelectorAll('[data-station]')].map(card=>({{name:card.querySelector('[data-station-field="name"]').value,city:card.querySelector('[data-station-field="city"]').value,id:card.querySelector('[data-station-field="id"]').value,label:card.querySelector('[data-station-field="label"]').value,serviceTypes:JSON.parse(card.querySelector('[data-station-field="serviceTypes"]').value||'[]'),routes:[...card.querySelectorAll('[data-route="line"]')].map((line,index)=>({{line:line.value,destination:card.querySelectorAll('[data-route="destination"]')[index].value}}))}}));document.getElementById('config_json').value=JSON.stringify(config);document.getElementById('save-settings').disabled=true;document.getElementById('save-settings').textContent='Geofox prüft …';return true}}
+function applyStation(select){{if(!select.value)return;const station=JSON.parse(select.value);const card=select.closest('[data-station]');card.querySelector('[data-station-field="name"]').value=station.name;card.querySelector('[data-station-field="city"]').value=station.city;card.querySelector('[data-station-field="id"]').value=station.id;card.querySelector('[data-station-field="serviceTypes"]').value=JSON.stringify(station.serviceTypes||[]);card.dataset.valid='true';card.querySelector('[data-search-message]').innerHTML='<span class="ok">✓ Geofox-Haltestelle ausgewählt</span>';card.querySelector('[data-load-lines]').disabled=false;card.querySelector('[data-routes]').replaceChildren();loadLines(card.querySelector('[data-load-lines]'))}}
+function addStation(){{const first=document.querySelector('[data-station]');const clone=first.cloneNode(true);clone.querySelectorAll('input').forEach(input=>input.value=input.dataset.stationField==='city'?'Hamburg':(input.dataset.stationField==='serviceTypes'?'[]':''));clone.querySelector('[data-routes]').replaceChildren();clone.querySelector('[data-line-options]').replaceChildren();clone.querySelector('[data-line-picker]').dataset.selectedLines='[]';clone.querySelector('[data-station-results]').replaceChildren(new Option('Treffer auswählen …',''));invalidateStation(clone);document.getElementById('stations').appendChild(clone);bindStation(clone)}}
+function renderLineOptions(card, lines){{const picker=card.querySelector('[data-line-picker]');const box=card.querySelector('[data-line-options]');let selected=[];try{{selected=JSON.parse(picker.dataset.selectedLines||'[]').map(item=>item.id)}}catch(error){{selected=[]}}box.replaceChildren();lines.forEach(line=>{{const label=document.createElement('label');label.className='line-option';const input=document.createElement('input');input.type='checkbox';input.dataset.lineOption='true';input.value=line.id;input.dataset.line=line.name;input.dataset.product=line.product;input.checked=selected.includes(line.id);label.append(input,document.createTextNode(line.name+' · '+line.productLabel+(line.carrier?' · '+line.carrier:'')));box.append(label)}})}}
+async function loadLines(button){{const card=button.closest('[data-station]');const stationId=card.querySelector('[data-station-field="id"]').value.trim();const message=card.querySelector('[data-lines-message]');if(!stationId){{message.textContent='Bitte zuerst eine Geofox-Haltestelle auswählen.';return}}const sequence=(lineSequences.get(card)||0)+1;lineSequences.set(card,sequence);lineControllers.get(card)?.abort();const controller=new AbortController();lineControllers.set(card,controller);button.disabled=true;message.innerHTML='<span class="spinner" aria-hidden="true"></span> Linien werden geladen …';try{{const response=await fetch('/api/lines?station_id='+encodeURIComponent(stationId),{{signal:controller.signal}});const data=await response.json();if(lineSequences.get(card)!==sequence)return;if(!response.ok)throw new Error(data.error||'Linien konnten nicht geladen werden');renderLineOptions(card,data.lines);message.textContent=data.lines.length?'Linien aller verfügbaren Verkehrsmittel auswählen.':'Für diese Haltestelle wurden keine Linien gefunden.'}}catch(error){{if(error.name!=='AbortError')message.textContent=error.message}}finally{{if(lineSequences.get(card)===sequence)button.disabled=false}}}}
+function selectedRoutes(card){{const manual=[...card.querySelectorAll('[data-route="line"]')].map(line=>{{const row=line.closest('.route-row');return {{line:line.value.trim(),destination:row.querySelector('[data-route="destination"]').value.trim(),line_id:row.querySelector('[data-route-line-id]').value.trim()||undefined,product:row.querySelector('[data-route-product]').value.trim()||undefined}}}}).filter(route=>route.line&&!route.line_id);const selected=[...card.querySelectorAll('[data-line-option]')].filter(input=>input.checked).map(input=>({{line:input.dataset.line,destination:'',line_id:input.value,product:input.dataset.product}}));return [...selected,...manual]}}
+function prepareConfig(){{const invalid=[...document.querySelectorAll('[data-station]')].find(card=>card.dataset.valid!=='true');if(invalid){{invalid.querySelector('[data-search-message]').innerHTML='<span class="error">Bitte zuerst einen gültigen Geofox-Vorschlag auswählen.</span>';invalid.scrollIntoView({{behavior:'smooth',block:'center'}});return false}}const config=JSON.parse(document.getElementById('config_json').value);document.querySelectorAll('[data-path]').forEach(control=>{{const [section,key]=control.dataset.path.split('.');config[section][key]=control.dataset.type==='bool'?control.value==='true':(control.type==='number'?Number(control.value):control.value)}});config.stations=[...document.querySelectorAll('[data-station]')].map(card=>({{name:card.querySelector('[data-station-field="name"]').value,city:card.querySelector('[data-station-field="city"]').value,id:card.querySelector('[data-station-field="id"]').value,label:card.querySelector('[data-station-field="label"]').value,serviceTypes:JSON.parse(card.querySelector('[data-station-field="serviceTypes"]').value||'[]'),routes:selectedRoutes(card)}}));document.getElementById('config_json').value=JSON.stringify(config);document.getElementById('save-settings').disabled=true;document.getElementById('save-settings').textContent='Geofox prüft …';return true}}
 document.querySelectorAll('[data-station]').forEach(bindStation);document.querySelectorAll('[data-station-results]').forEach(select=>select.addEventListener('change',()=>applyStation(select)));
 </script>'''
         return _page("Einstellungen", content)
@@ -551,6 +626,24 @@ def make_handler(application: WebApplication) -> type[BaseHTTPRequestHandler]:
                 except (ConfigError, OSError, ValueError) as exc:
                     self._send_json(
                         {"stations": [], "error": str(exc)}, HTTPStatus.BAD_REQUEST
+                    )
+                return
+            if path == "/api/lines":
+                query = parse_qs(urlsplit(self.path).query)
+                try:
+                    lines = application.line_suggestions(
+                        query.get("station_id", [""])[0]
+                    )
+                    self._send_json({"lines": lines})
+                except GeofoxError as exc:
+                    self._send_json(
+                        {"lines": [], "error": str(exc)},
+                        _geofox_http_status(exc),
+                        retry_after=exc.retry_after_seconds,
+                    )
+                except (ConfigError, OSError, ValueError) as exc:
+                    self._send_json(
+                        {"lines": [], "error": str(exc)}, HTTPStatus.BAD_REQUEST
                     )
                 return
             self.send_error(HTTPStatus.NOT_FOUND)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -142,6 +142,29 @@ class ConfigTest(unittest.TestCase):
                     with self.assertRaisesRegex(ConfigError, "größer als 0"):
                         load_config(self.write_config(raw, directory))
 
+    def test_multimodal_line_route_can_omit_destination(self) -> None:
+        raw = json.loads(Path("config.example.json").read_text(encoding="utf-8"))
+        raw["stations"][0]["routes"] = [
+            {"line": "U2", "line_id": "line:U2", "product": "UBAHN"}
+        ]
+        with tempfile.TemporaryDirectory() as directory:
+            config = load_config(self.write_config(raw, directory))
+        route = config.stations[0].routes[0]
+        self.assertEqual(route.line, "U2")
+        self.assertEqual(route.destination, "")
+        self.assertEqual(route.line_id, "line:U2")
+        self.assertEqual(route.product, "UBAHN")
+
+        raw["stations"][0]["routes"] = [{"line": "", "destination": ""}]
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(ConfigError, "destination oder line_id"):
+                load_config(self.write_config(raw, directory))
+
+        raw["stations"][0]["routes"] = [None]
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(ConfigError, "muss Objekte enthalten"):
+                load_config(self.write_config(raw, directory))
+
     def test_station_label_length_and_empty_routes_are_rejected(self) -> None:
         original = json.loads(Path("config.example.json").read_text(encoding="utf-8"))
         for label in (" ", "LANG"):

--- a/tests/test_geofox.py
+++ b/tests/test_geofox.py
@@ -1,6 +1,7 @@
 import base64
 import hashlib
 import hmac
+import json
 import unittest
 import urllib.error
 from datetime import datetime
@@ -8,10 +9,13 @@ from unittest.mock import patch
 
 from hvv_display.geofox import (
     HAMBURG_TZ,
+    MAX_LINE_OPTIONS,
     GeofoxClient,
     GeofoxError,
+    line_options_for_station,
     normalize,
     route_matches,
+    vehicle_type_label,
 )
 from hvv_display.models import Route, Station
 
@@ -45,10 +49,162 @@ class GeofoxClientTest(unittest.TestCase):
         self.assertIn("Straße".encode(), body)
 
     def test_route_matching_handles_spelling_variants(self) -> None:
-        routes = (Route("384", "Elbgaustrasse"),)
+        routes = (Route("384", "Elbgaustrasse"), Route("U2", ""))
         self.assertTrue(route_matches("384", "S Elbgaustraße", routes))
         self.assertFalse(route_matches("184", "S Elbgaustraße", routes))
+        self.assertTrue(route_matches("U2", "Niendorf Nord", routes))
         self.assertEqual(normalize("Recknitzstraße"), "recknitzstrasse")
+
+    def test_line_options_filter_by_station_and_expose_vehicle_metadata(self) -> None:
+        lines = [
+            {
+                "id": "line:5",
+                "name": "5",
+                "type": {"simpleType": "BUS"},
+                "carrierNameShort": "HHA",
+                "sublines": [
+                    {
+                        "vehicleType": "METROBUS",
+                        "stationSequence": [{"id": "Master:1"}],
+                    }
+                ],
+            },
+            {
+                "id": "line:U2",
+                "name": "U2",
+                "type": {"simpleType": "TRAIN"},
+                "sublines": [
+                    {
+                        "vehicleType": {"simpleType": "UBAHN"},
+                        "stationSequence": [{"id": "Master:1"}],
+                    }
+                ],
+            },
+            {
+                "id": "line:S1",
+                "name": "S1",
+                "sublines": [
+                    {
+                        "vehicleType": "SBAHN",
+                        "stationSequence": [{"id": "Master:2"}],
+                    }
+                ],
+            },
+            {"id": "gone", "name": "Gone", "exists": False, "sublines": []},
+            {"id": "no-sequence", "name": "No", "sublines": []},
+            {
+                "id": "unknown",
+                "name": "X",
+                "sublines": [
+                    {"stationSequence": [{"id": "Master:1"}]},
+                ],
+            },
+            {"id": "", "name": "Empty", "sublines": []},
+            {"id": "no-name", "name": "", "sublines": []},
+            {"id": "tuple-sequence", "name": "Tuple", "sublines": ()},
+            {
+                "id": "bad-subline",
+                "name": "Bad",
+                "sublines": ["not an object"],
+            },
+            {
+                "id": "line:5",
+                "name": "Duplicate",
+                "sublines": [
+                    {
+                        "vehicleType": "BUS",
+                        "stationSequence": [{"id": "Master:1"}],
+                    }
+                ],
+            },
+        ]
+        options = line_options_for_station(lines, "Master:1")
+        self.assertEqual([option.name for option in options], ["5", "U2", "X"])
+        self.assertEqual(options[0].product, "METROBUS")
+        self.assertEqual(options[0].product_label, "MetroBus")
+        self.assertEqual(options[0].carrier, "HHA")
+        self.assertEqual(options[1].product_label, "U-Bahn")
+        self.assertEqual(options[2].product, "UNKNOWN")
+        self.assertEqual(options[2].product_label, "Unbekanntes Verkehrsmittel")
+        self.assertEqual(line_options_for_station(None, "Master:1"), ())
+        self.assertEqual(vehicle_type_label("FAEHRE"), "Fähre")
+        self.assertEqual(
+            vehicle_type_label("not-a-real-type"), "Unbekanntes Verkehrsmittel"
+        )
+
+        limited = [
+            {
+                "id": f"line:{index}",
+                "name": str(index),
+                "sublines": [
+                    {
+                        "vehicleType": "BUS",
+                        "stationSequence": [{"id": "Master:1"}],
+                    }
+                ],
+            }
+            for index in range(MAX_LINE_OPTIONS + 1)
+        ]
+        self.assertEqual(
+            len(line_options_for_station(limited, "Master:1")), MAX_LINE_OPTIONS
+        )
+
+    def test_list_lines_requests_all_sublines(self) -> None:
+        response = FakeResponse(
+            b'{"returnCode":"OK","dataReleaseID":"release-1",'
+            b'"lines":[{"id":"line:5","name":"5","sublines":[]}]} '
+        )
+        requests = []
+
+        def urlopen(request, **_kwargs):
+            requests.append(json.loads(request.data.decode("utf-8")))
+            return response
+
+        client = GeofoxClient(
+            "https://example.test",
+            "user",
+            "secret",
+            min_request_interval=0,
+            urlopen=urlopen,
+        )
+        self.assertEqual(client.list_lines()[0]["name"], "5")
+        self.assertEqual(requests[0]["dataReleaseID"], "")
+        self.assertEqual(requests[0]["withSublines"], True)
+        self.assertEqual(requests[0]["modificationTypes"], ["MAIN", "SEQUENCE"])
+
+        invalid = GeofoxClient(
+            "https://example.test",
+            "user",
+            "secret",
+            min_request_interval=0,
+            urlopen=lambda *_args, **_kwargs: FakeResponse(
+                b'{"returnCode":"OK","lines":{}}'
+            ),
+        )
+        with self.assertRaisesRegex(GeofoxError, "Linienliste"):
+            invalid.list_lines()
+
+        missing = GeofoxClient(
+            "https://example.test",
+            "user",
+            "secret",
+            min_request_interval=0,
+            urlopen=lambda *_args, **_kwargs: FakeResponse(
+                b'{"returnCode":"OK"}'
+            ),
+        )
+        self.assertEqual(missing.list_lines(), [])
+
+        line_options = GeofoxClient(
+            "https://example.test",
+            "user",
+            "secret",
+            min_request_interval=0,
+            urlopen=lambda *_args, **_kwargs: FakeResponse(
+                b'{"returnCode":"OK","lines":[]}'
+            ),
+        )
+        self.assertEqual(line_options.line_options("Master:1"), ())
 
     def test_find_stations_returns_service_types_for_follow_up_flow(self) -> None:
         response = FakeResponse(
@@ -185,6 +341,52 @@ class GeofoxClientTest(unittest.TestCase):
         self.assertEqual([departure.line for departure in result], ["21", "186"])
         self.assertEqual(result[0].departure_time.strftime("%H:%M"), "12:04")
         self.assertEqual(result[1].departure_time.strftime("%H:%M"), "12:11")
+
+    def test_departures_support_multimodal_line_ids_without_bus_restriction(
+        self,
+    ) -> None:
+        response = FakeResponse(
+            b'{"returnCode":"OK","departures":['
+            b'{"line":{"name":"U2","direction":"Niendorf Nord",'
+            b'"type":"UBAHN"},"timeOffset":4},'
+            b'{"line":{"name":"5","direction":"Burgwedel",'
+            b'"type":"BUS"},"timeOffset":6}]}'
+        )
+        requests = []
+
+        def urlopen(request, **_kwargs):
+            requests.append(json.loads(request.data.decode("utf-8")))
+            return response
+
+        client = GeofoxClient(
+            "https://example.test",
+            "user",
+            "secret",
+            min_request_interval=0,
+            urlopen=urlopen,
+        )
+        station = Station(
+            "Jungfernstieg",
+            "Hamburg",
+            (
+                Route("U2", "", "line:U2", "UBAHN"),
+                Route("5", "", "line:5", "BUS"),
+            ),
+            "Master:1",
+        )
+        result = client.departure_list(
+            (station,), now=datetime(2026, 7, 27, 12, 0, tzinfo=HAMBURG_TZ)
+        )
+        self.assertEqual([departure.line for departure in result], ["U2", "5"])
+        self.assertEqual([departure.product for departure in result], ["UBAHN", "BUS"])
+        self.assertNotIn("serviceTypes", requests[0])
+        self.assertEqual(
+            requests[0]["filter"],
+            [
+                {"serviceID": "line:U2", "serviceName": "U2"},
+                {"serviceID": "line:5", "serviceName": "5"},
+            ],
+        )
 
     def test_offset_uses_real_minutes_across_daylight_saving_change(self) -> None:
         response = FakeResponse(

--- a/tests/test_station_management.py
+++ b/tests/test_station_management.py
@@ -38,12 +38,52 @@ class StationManagementTest(unittest.TestCase):
         self.assertIn("scheduleStationSearch", page)
         self.assertIn("Geofox wird abgefragt", page)
         self.assertIn("Richtung oder Zielstation?", page)
+        self.assertIn("Verfügbare Linien laden", page)
+        self.assertIn("data-line-options", page)
+        self.assertIn("Mehrere Verkehrsmittel werden gemeinsam angeboten", page)
 
     def test_station_search_validates_lengths_before_geofox_request(self) -> None:
         with self.assertRaisesRegex(ValueError, "zu lang"):
             self.app.station_suggestions("x" * 121, "Hamburg")
         with self.assertRaisesRegex(ValueError, "mindestens zwei"):
             self.app.station_suggestions("x", "Hamburg")
+
+    def test_line_suggestions_are_station_specific_and_cached(self) -> None:
+        lines = [
+            {
+                "id": "line:5",
+                "name": "5",
+                "type": "BUS",
+                "carrierNameShort": "HHA",
+                "sublines": [
+                    {
+                        "vehicleType": "BUS",
+                        "stationSequence": [{"id": "Master:1"}],
+                    }
+                ],
+            },
+            {
+                "id": "line:S1",
+                "name": "S1",
+                "type": "SBAHN",
+                "sublines": [
+                    {
+                        "vehicleType": "SBAHN",
+                        "stationSequence": [{"id": "Master:2"}],
+                    }
+                ],
+            },
+        ]
+        with patch.object(self.app, "_client") as client:
+            client.return_value.list_lines.return_value = lines
+            first = self.app.line_suggestions("Master:1")
+            second = self.app.line_suggestions("Master:1")
+        self.assertEqual(first, second)
+        self.assertEqual(first[0]["productLabel"], "Bus")
+        client.return_value.list_lines.assert_called_once_with()
+
+        with self.assertRaisesRegex(ValueError, "ungültig"):
+            self.app.line_suggestions("bad\nstation")
 
     def test_station_config_is_revalidated_and_enriched_before_save(self) -> None:
         raw = json.loads(self.config.read_text(encoding="utf-8"))
@@ -76,6 +116,53 @@ class StationManagementTest(unittest.TestCase):
             validated["stations"][0]["serviceTypes"], ["BUS", "UBAHN", "SBAHN"]
         )
         self.assertEqual(validated["stations"][0]["id"], "Master:1")
+
+    def test_multimodal_line_route_is_checked_against_geofox_catalog(self) -> None:
+        raw = json.loads(self.config.read_text(encoding="utf-8"))
+        raw["stations"] = [
+            {
+                "name": "Jungfernstieg",
+                "city": "Hamburg",
+                "id": "Master:1",
+                "label": "J",
+                "routes": [{"line_id": "line:U2", "line": "untrusted"}],
+            }
+        ]
+        matches = [{"name": "Jungfernstieg", "city": "Hamburg", "id": "Master:1"}]
+        lines = [
+            {
+                "id": "line:U2",
+                "name": "U2",
+                "sublines": [
+                    {
+                        "vehicleType": "UBAHN",
+                        "stationSequence": [{"id": "Master:1"}],
+                    }
+                ],
+            }
+        ]
+        with patch.object(self.app, "_client") as client:
+            client.return_value.find_stations.return_value = matches
+            client.return_value.list_lines.return_value = lines
+            validated = self.app.validate_station_config(
+                raw, user="test", password="secret"  # noqa: S106
+            )
+        route = validated["stations"][0]["routes"][0]
+        self.assertEqual(route, {
+            "line_id": "line:U2",
+            "line": "U2",
+            "product": "UBAHN",
+            "destination": "",
+        })
+
+        raw["stations"][0]["routes"][0]["line_id"] = "line:missing"
+        with patch.object(self.app, "_client") as client:
+            client.return_value.find_stations.return_value = matches
+            client.return_value.list_lines.return_value = lines
+            with self.assertRaisesRegex(ValueError, "nicht verfügbar"):
+                self.app.validate_station_config(
+                    raw, user="test", password="secret"  # noqa: S106
+                )
 
     def test_station_config_rejects_unselected_or_stale_station(self) -> None:
         raw = json.loads(self.config.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary
- add Geofox listLines cataloging for all supported transport modes
- let the settings UI select multiple lines with stable IDs and safe mode labels
- keep legacy bus routes compatible and filter departures by selected Geofox line IDs

## Verification
- local targeted tests, compileall, Ruff, pip-audit, package build, and preview pass
- Linux-only shell/systemd checks will run in CI

Closes #44