### PR TITLE
fix: Linienfilter für Richtung und Zielstation

### DIFF
--- a/hvv_display/config.py
+++ b/hvv_display/config.py
@@ -10,6 +10,8 @@ from urllib.parse import urlsplit
 
 from .models import Route, Station
 
+MAX_ROUTE_FILTER_STATIONS = 200
+
 
 class ConfigError(ValueError):
     """Raised when the local configuration is incomplete or invalid."""
@@ -213,9 +215,39 @@ def _route_from_raw(route: Any, section: str) -> Route:
     if not line or (not destination and not line_id):
         raise ConfigError(f"{section}.destination oder line_id muss gesetzt sein")
     product = route.get("product")
+    filter_mode = route.get("filter_mode")
+    filter_mode = str(filter_mode).strip() if filter_mode is not None else None
+    if filter_mode == "":
+        filter_mode = None
+    if filter_mode not in (None, "direction", "destination"):
+        raise ConfigError(
+            f"{section}.filter_mode muss direction oder destination sein"
+        )
+    raw_filter_station_ids = route.get("filter_station_ids", [])
+    if not isinstance(raw_filter_station_ids, (list, tuple)):
+        raise ConfigError(f"{section}.filter_station_ids muss eine Liste sein")
+    if len(raw_filter_station_ids) > MAX_ROUTE_FILTER_STATIONS:
+        raise ConfigError(
+            f"{section}.filter_station_ids enthält zu viele Haltestellen"
+        )
+    filter_station_ids = tuple(
+        str(station_id).strip()
+        for station_id in raw_filter_station_ids
+        if str(station_id).strip()
+    )
+    if filter_mode and not filter_station_ids:
+        raise ConfigError(
+            f"{section}.filter_station_ids muss für einen Filter gesetzt sein"
+        )
+    if filter_station_ids and not filter_mode:
+        raise ConfigError(
+            f"{section}.filter_mode muss für filter_station_ids gesetzt sein"
+        )
     return Route(
         line=line,
         destination=destination,
         line_id=line_id or None,
         product=str(product).strip() if product is not None else None,
+        filter_mode=filter_mode,
+        filter_station_ids=filter_station_ids,
     )

--- a/hvv_display/geofox.py
+++ b/hvv_display/geofox.py
@@ -19,13 +19,15 @@ from typing import Any
 from urllib.parse import urlsplit
 from zoneinfo import ZoneInfo
 
-from .models import Departure, LineOption, Route, Station
+from .models import Departure, LineOption, LineRouteOption, Route, Station
 
 LOG = logging.getLogger(__name__)
 HAMBURG_TZ = ZoneInfo("Europe/Berlin")
 MAX_RESPONSE_BYTES = 1024 * 1024
 MAX_RETRY_AFTER_SECONDS = 3600
 MAX_LINE_OPTIONS = 200
+MAX_ROUTE_STATIONS = 200
+MAX_ROUTE_STATION_SUGGESTIONS = 80
 _VEHICLE_LABELS = {
     "UBAHN": "U-Bahn",
     "SBAHN": "S-Bahn",
@@ -98,12 +100,21 @@ def normalize(value: str) -> str:
     )
 
 
-def route_matches(line_name: str, direction: str, routes: tuple[Route, ...]) -> bool:
+def route_matches(
+    line_name: str,
+    direction: str,
+    routes: tuple[Route, ...],
+    line_id: str | None = None,
+) -> bool:
     normalized_direction = normalize(direction)
     for route in routes:
         expected = normalize(route.destination)
+        if route.line_id and line_id and route.line_id != line_id:
+            continue
         if normalize(line_name) != normalize(route.line):
             continue
+        if route.filter_station_ids:
+            return True
         if not expected or (
             expected in normalized_direction or normalized_direction in expected
         ):
@@ -210,6 +221,91 @@ def line_options_for_station(
             )
             break
     return tuple(options)
+
+
+def line_route_options_for_station(
+    lines: Any, line_id: str, station_id: str
+) -> tuple[LineRouteOption, ...]:
+    """Return each downstream line branch available from a station."""
+    raw_lines = lines if isinstance(lines, list) else []
+    matching_line = next(
+        (
+            raw_line
+            for raw_line in raw_lines
+            if isinstance(raw_line, dict)
+            and raw_line.get("exists") is not False
+            and _safe_external_text(raw_line.get("id"), 160) == line_id
+        ),
+        None,
+    )
+    if matching_line is None:
+        return ()
+    options: list[LineRouteOption] = []
+    seen: set[tuple[str, ...]] = set()
+    sublines = matching_line.get("sublines")
+    if not isinstance(sublines, list):
+        return ()
+    for subline in sublines:
+        if not isinstance(subline, dict):
+            continue
+        sequence = subline.get("stationSequence")
+        if not isinstance(sequence, list):
+            continue
+        stops = [
+            (
+                _safe_external_text(stop.get("id"), 160),
+                _safe_external_text(stop.get("name"), 120),
+            )
+            for stop in sequence
+            if isinstance(stop, dict) and stop.get("id")
+        ]
+        for index, (stop_id, _stop_name) in enumerate(stops):
+            if stop_id != station_id:
+                continue
+            # Geofox evaluates stationIDs against the downstream direction.
+            # Keeping the source station here would make every departure match.
+            downstream = stops[index + 1 : index + 1 + MAX_ROUTE_STATIONS]
+            downstream_ids = tuple(stop[0] for stop in downstream)
+            if not downstream_ids or downstream_ids in seen:
+                continue
+            seen.add(downstream_ids)
+            end_name = downstream[-1][1] or downstream[-1][0]
+            options.append(
+                LineRouteOption(
+                    line_id=line_id,
+                    label=f"Richtung {end_name}",
+                    station_ids=downstream_ids,
+                    stations=tuple(downstream),
+                )
+            )
+            if len(options) >= MAX_LINE_OPTIONS:
+                LOG.warning(
+                    "Richtungsoptionen für Linie %s auf %d Einträge begrenzt",
+                    line_id,
+                    MAX_LINE_OPTIONS,
+                )
+                return tuple(options)
+    return tuple(options)
+
+
+def line_route_stations(
+    options: tuple[LineRouteOption, ...], query: str = ""
+) -> tuple[dict[str, str], ...]:
+    """Return bounded, deduplicated downstream station suggestions."""
+    normalized_query = normalize(query) if query else ""
+    suggestions: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for option in options:
+        for station_id, name in option.stations:
+            if station_id in seen or (
+                normalized_query and normalized_query not in normalize(name)
+            ):
+                continue
+            seen.add(station_id)
+            suggestions.append({"id": station_id, "name": name})
+            if len(suggestions) >= MAX_ROUTE_STATION_SUGGESTIONS:
+                return tuple(suggestions)
+    return tuple(suggestions)
 
 
 def _return_code_error(result: dict[str, Any]) -> GeofoxError:
@@ -466,6 +562,17 @@ class GeofoxClient:
     def line_options(self, station_id: str) -> tuple[LineOption, ...]:
         return line_options_for_station(self.list_lines(), station_id)
 
+    def line_route_options(
+        self, station_id: str, line_id: str
+    ) -> tuple[LineRouteOption, ...]:
+        return line_route_options_for_station(self.list_lines(), line_id, station_id)
+
+    def line_route_stations(
+        self, station_id: str, line_id: str, query: str = ""
+    ) -> tuple[dict[str, str], ...]:
+        options = self.line_route_options(station_id, line_id)
+        return line_route_stations(options, query)
+
     def departure_list(
         self,
         stations: tuple[Station, ...],
@@ -488,15 +595,24 @@ class GeofoxClient:
             "maxTimeOffset": max_time_offset,
             "useRealtime": True,
         }
-        filters = [
-            {
-                "serviceID": route.line_id,
-                "serviceName": route.line,
-            }
-            for station in stations
-            for route in station.routes
-            if route.line_id
-        ]
+        filters = []
+        seen_filter_keys: set[tuple[str, tuple[str, ...]]] = set()
+        for station in stations:
+            for route in station.routes:
+                if not route.line_id:
+                    continue
+                station_ids = tuple(route.filter_station_ids)
+                filter_key = (route.line_id, station_ids)
+                if filter_key in seen_filter_keys:
+                    continue
+                seen_filter_keys.add(filter_key)
+                entry: dict[str, Any] = {
+                    "serviceID": route.line_id,
+                    "serviceName": route.line,
+                }
+                if station_ids:
+                    entry["stationIDs"] = list(station_ids)
+                filters.append(entry)
         if filters:
             payload["filter"] = filters
         if len(station_names) == 1:
@@ -522,6 +638,11 @@ class GeofoxClient:
                 continue
             line_name = str(line.get("name", ""))
             direction = str(line.get("direction", ""))
+            response_line_id = (
+                _safe_external_text(line.get("id"), 160)
+                if line.get("id")
+                else None
+            )
             product = _safe_vehicle_product(
                 line.get("type") or line.get("vehicleType")
             )
@@ -535,14 +656,21 @@ class GeofoxClient:
             if selected_station:
                 matching_stations = (
                     [selected_station]
-                    if route_matches(line_name, direction, selected_station.routes)
+                    if route_matches(
+                        line_name,
+                        direction,
+                        selected_station.routes,
+                        response_line_id,
+                    )
                     else []
                 )
             else:
                 matching_stations = [
                     station
                     for station in stations
-                    if route_matches(line_name, direction, station.routes)
+                    if route_matches(
+                        line_name, direction, station.routes, response_line_id
+                    )
                 ]
             if not matching_stations:
                 continue

--- a/hvv_display/models.py
+++ b/hvv_display/models.py
@@ -10,6 +10,8 @@ class Route:
     destination: str
     line_id: str | None = None
     product: str | None = None
+    filter_mode: str | None = None
+    filter_station_ids: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -19,6 +21,14 @@ class LineOption:
     product: str
     product_label: str
     carrier: str = ""
+
+
+@dataclass(frozen=True)
+class LineRouteOption:
+    line_id: str
+    label: str
+    station_ids: tuple[str, ...]
+    stations: tuple[tuple[str, str], ...]
 
 
 @dataclass(frozen=True)

--- a/hvv_display/web.py
+++ b/hvv_display/web.py
@@ -29,6 +29,8 @@ from .geofox import (
     GeofoxClient,
     GeofoxError,
     line_options_for_station,
+    line_route_options_for_station,
+    line_route_stations,
 )
 from .render import get_line_style, line_style_css
 from .stations import resolve_stations
@@ -316,6 +318,66 @@ class WebApplication:
             for option in options
         ]
 
+    @staticmethod
+    def _validate_geofox_identifier(value: str, label: str) -> str:
+        value = value.strip()
+        if not value or len(value) > MAX_STATION_ID_LENGTH:
+            raise ValueError(f"{label} ist ungültig")
+        if any(character in value for character in ("\r", "\n", "\x00")):
+            raise ValueError(f"{label} ist ungültig")
+        return value
+
+    def line_route_suggestions(
+        self, station_id: str, line_id: str
+    ) -> list[dict[str, Any]]:
+        station_id = self._validate_geofox_identifier(station_id, "Geofox-ID")
+        line_id = self._validate_geofox_identifier(line_id, "Linien-ID")
+        client = self._client()
+        if self._line_catalog is None:
+            self._line_catalog = client.list_lines()
+        available = {
+            option.line_id
+            for option in line_options_for_station(self._line_catalog, station_id)
+        }
+        if line_id not in available:
+            raise ValueError("Linie ist an dieser Haltestelle nicht verfügbar")
+        options = line_route_options_for_station(
+            self._line_catalog, line_id, station_id
+        )
+        return [
+            {
+                "label": option.label,
+                "stationIds": list(option.station_ids),
+                "stations": [
+                    {"id": station[0], "name": station[1]}
+                    for station in option.stations
+                ],
+            }
+            for option in options
+        ]
+
+    def line_station_suggestions(
+        self, station_id: str, line_id: str, query: str = ""
+    ) -> list[dict[str, str]]:
+        station_id = self._validate_geofox_identifier(station_id, "Geofox-ID")
+        line_id = self._validate_geofox_identifier(line_id, "Linien-ID")
+        query = query.strip()
+        if len(query) > MAX_QUERY_LENGTH:
+            raise ValueError("Suchbegriff ist zu lang")
+        client = self._client()
+        if self._line_catalog is None:
+            self._line_catalog = client.list_lines()
+        available = {
+            option.line_id
+            for option in line_options_for_station(self._line_catalog, station_id)
+        }
+        if line_id not in available:
+            raise ValueError("Linie ist an dieser Haltestelle nicht verfügbar")
+        options = line_route_options_for_station(
+            self._line_catalog, line_id, station_id
+        )
+        return list(line_route_stations(options, query))
+
     def validate_station_config(
         self, raw_config: dict[str, Any], *, user: str, password: str
     ) -> dict[str, Any]:
@@ -356,10 +418,12 @@ class WebApplication:
                 raise ValueError(
                     f"Haltestelle {index + 1}: Mindestens eine Linie auswählen"
                 )
+            if any(not isinstance(route, dict) for route in routes):
+                raise ValueError(f"Haltestelle {index + 1}: Linie ist ungültig")
             line_ids = {
                 str(route.get("line_id")).strip()
                 for route in routes
-                if isinstance(route, dict) and route.get("line_id")
+                if route.get("line_id")
             }
             if line_ids:
                 if self._line_catalog is None:
@@ -371,10 +435,12 @@ class WebApplication:
                     )
                 }
                 for route in routes:
-                    if not isinstance(route, dict):
-                        raise ValueError(f"Haltestelle {index + 1}: Linie ist ungültig")
                     line_id = str(route.get("line_id") or "").strip()
                     if not line_id:
+                        if route.get("filter_mode") or route.get("filter_station_ids"):
+                            raise ValueError(
+                                f"Haltestelle {index + 1}: Filter benötigt eine Geofox-Linien-ID"
+                            )
                         continue
                     option = available.get(line_id)
                     if option is None:
@@ -383,7 +449,54 @@ class WebApplication:
                         )
                     route["line"] = option.name
                     route["product"] = option.product
-                    route["destination"] = str(route.get("destination") or "").strip()
+                    mode = str(route.get("filter_mode") or "").strip()
+                    raw_station_ids = route.get("filter_station_ids")
+                    if mode not in ("direction", "destination"):
+                        raise ValueError(
+                            f"Haltestelle {index + 1}: Für Linie {option.name} Richtung oder Zielstation auswählen"
+                        )
+                    if not isinstance(raw_station_ids, list) or not raw_station_ids:
+                        raise ValueError(
+                            f"Haltestelle {index + 1}: Filter für Linie {option.name} ist ungültig"
+                        )
+                    station_ids = tuple(
+                        str(station_id).strip()
+                        for station_id in raw_station_ids
+                        if str(station_id).strip()
+                    )
+                    route_options = line_route_options_for_station(
+                        self._line_catalog, line_id, station["id"]
+                    )
+                    if mode == "direction":
+                        matches = [
+                            candidate
+                            for candidate in route_options
+                            if candidate.station_ids == station_ids
+                        ]
+                        if len(matches) != 1:
+                            raise ValueError(
+                                f"Haltestelle {index + 1}: Die gewählte Richtung konnte für {option.name} nicht eindeutig bestimmt werden"
+                            )
+                        route["destination"] = matches[0].label
+                        route["filter_station_ids"] = list(matches[0].station_ids)
+                    else:
+                        if len(station_ids) != 1:
+                            raise ValueError(
+                                f"Haltestelle {index + 1}: Eine Zielstation auswählen"
+                            )
+                        valid_stations = {
+                            station_option[0]: station_option[1]
+                            for route_option in route_options
+                            for station_option in route_option.stations
+                        }
+                        target_name = valid_stations.get(station_ids[0])
+                        if target_name is None:
+                            raise ValueError(
+                                f"Haltestelle {index + 1}: Zielstation liegt ab dieser Haltestelle nicht auf Linie {option.name}"
+                            )
+                        route["destination"] = target_name
+                        route["filter_station_ids"] = [station_ids[0]]
+                    route["filter_mode"] = mode
         return raw_config
 
     def dashboard(self) -> bytes:
@@ -470,7 +583,7 @@ class WebApplication:
                 json.dumps(selected_lines, ensure_ascii=False), quote=True
             )
             routes = "".join(
-                f'<div class="route-row"><input data-route="line" value="{html.escape(str(route.get("line", "")), quote=True)}" placeholder="Linie" aria-label="Linie"><input data-route="destination" value="{html.escape(str(route.get("destination", "")), quote=True)}" placeholder="Ziel" aria-label="Ziel"><input type="hidden" data-route-line-id value="{html.escape(str(route.get("line_id") or ""), quote=True)}"><input type="hidden" data-route-product value="{html.escape(str(route.get("product") or ""), quote=True)}"><button type="button" class="reset" onclick="this.parentElement.remove()">Route entfernen</button></div>'
+                f'<div class="route-row"><input data-route="line" value="{html.escape(str(route.get("line", "")), quote=True)}" placeholder="Linie" aria-label="Linie"><input data-route="destination" value="{html.escape(str(route.get("destination", "")), quote=True)}" placeholder="Ziel" aria-label="Ziel"><input type="hidden" data-route-line-id value="{html.escape(str(route.get("line_id") or ""), quote=True)}"><input type="hidden" data-route-product value="{html.escape(str(route.get("product") or ""), quote=True)}"><input type="hidden" data-route-filter-mode value="{html.escape(str(route.get("filter_mode") or ""), quote=True)}"><input type="hidden" data-route-filter-ids value="{html.escape(json.dumps(route.get("filter_station_ids") or [], ensure_ascii=False), quote=True)}"><button type="button" class="reset" onclick="this.parentElement.remove()">Route entfernen</button></div>'
                 for route in station.get("routes", [])
             )
             valid = bool(station.get("id"))
@@ -483,7 +596,7 @@ class WebApplication:
 <input type="hidden" data-station-field="serviceTypes" value="{html.escape(service_types, quote=True)}">
 <div class="station-search"><select data-station-results aria-label="Geofox-Haltestellenvorschläge"><option value="">Treffer auswählen …</option></select><span class="subtle" data-search-message>{'<span class="ok">✓ Geofox-Haltestelle ausgewählt</span>' if valid else "Bitte Haltestelle aus einem Geofox-Vorschlag auswählen."}</span></div>
 <details class="help-box"><summary>Richtung oder Zielstation?</summary><p><strong>Richtung</strong> wählt später den Linienast; auch Fahrten, die vorher enden, können angezeigt werden. <strong>Zu Zielstation</strong> zeigt nur Fahrten, die diese Station tatsächlich erreichen. Beispiel: U2 Richtung Niendorf Nord kann einen Kurzläufer nach Niendorf Markt enthalten; „Zu Zielstation Niendorf Nord“ nicht.</p></details>
-<h4>Linien und Ziele</h4><div data-line-picker data-selected-lines="{selected_lines_json}"><div class="control-row"><button type="button" data-load-lines onclick="loadLines(this)" {"disabled" if not valid else ""}>Verfügbare Linien laden</button><span class="subtle" data-lines-message>{'Mehrere Verkehrsmittel werden gemeinsam angeboten.' if valid else 'Nach der Haltestellenauswahl hier die verfügbaren Linien laden.'}</span></div><div data-line-options role="group" aria-label="Verfügbare Linien"></div></div><div data-routes>{routes}</div><details><summary>Legacy-Konfiguration manuell bearbeiten</summary><p class="subtle">Bestehende Bus-Konfigurationen bleiben kompatibel. Für neue Haltestellen bitte die Geofox-Linienauswahl verwenden.</p><button type="button" onclick="addRoute(this)">Route hinzufügen</button></details></article>'''
+<h4>Linien und Ziele</h4><div data-line-picker data-selected-lines="{selected_lines_json}"><div class="control-row"><button type="button" data-load-lines onclick="loadLines(this)" {"disabled" if not valid else ""}>Verfügbare Linien laden</button><span class="subtle" data-lines-message>{'Mehrere Verkehrsmittel gemeinsam auswählen und danach Richtung oder Zielstation festlegen.' if valid else 'Nach der Haltestellenauswahl hier die verfügbaren Linien laden.'}</span></div><div data-line-options role="group" aria-label="Verfügbare Linien"></div><div data-route-configs></div></div><div data-routes>{routes}</div><details><summary>Legacy-Konfiguration manuell bearbeiten</summary><p class="subtle">Bestehende Bus-Konfigurationen bleiben kompatibel. Für neue Haltestellen bitte die Geofox-Linienauswahl verwenden.</p><button type="button" onclick="addRoute(this)">Route hinzufügen</button></details></article>'''
 
         stations = "".join(
             station_card(station, index)
@@ -501,16 +614,19 @@ class WebApplication:
 <script>
 let requestSequence=0; let debounceTimers=new WeakMap(); let controllers=new WeakMap(); let lineControllers=new WeakMap(); let lineSequences=new WeakMap();
 function resetField(button){{const control=button.parentElement.querySelector('[data-path]');control.value=control.dataset.default}}
-function addRoute(button){{const row=document.createElement('div');row.className='route-row';row.innerHTML='<input data-route="line" placeholder="Linie" aria-label="Linie"><input data-route="destination" placeholder="Ziel" aria-label="Ziel"><input type="hidden" data-route-line-id><input type="hidden" data-route-product><button type="button" class="reset" onclick="this.parentElement.remove()">Route entfernen</button>';button.closest('[data-station]').querySelector('[data-routes]').appendChild(row)}}
-function invalidateStation(card){{card.dataset.valid='false';card.querySelector('[data-station-field="id"]').value='';card.querySelector('[data-station-field="serviceTypes"]').value='[]';card.querySelector('[data-search-message]').textContent='Bitte Haltestelle aus einem Geofox-Vorschlag auswählen.';card.querySelector('[data-line-options]').replaceChildren();card.querySelector('[data-lines-message]').textContent='Nach der Haltestellenauswahl hier die verfügbaren Linien laden.';card.querySelector('[data-load-lines]').disabled=true;lineControllers.get(card)?.abort();lineSequences.set(card,(lineSequences.get(card)||0)+1);card.querySelector('[data-routes]').replaceChildren();card.querySelector('[data-line-picker]').dataset.selectedLines='[]'}}
+function addRoute(button){{const row=document.createElement('div');row.className='route-row';row.innerHTML='<input data-route="line" placeholder="Linie" aria-label="Linie"><input data-route="destination" placeholder="Ziel" aria-label="Ziel"><input type="hidden" data-route-line-id><input type="hidden" data-route-product><input type="hidden" data-route-filter-mode><input type="hidden" data-route-filter-ids value="[]"><button type="button" class="reset" onclick="this.parentElement.remove()">Route entfernen</button>';button.closest('[data-station]').querySelector('[data-routes]').appendChild(row)}}
+function invalidateStation(card){{card.dataset.valid='false';card.querySelector('[data-station-field="id"]').value='';card.querySelector('[data-station-field="serviceTypes"]').value='[]';card.querySelector('[data-search-message]').textContent='Bitte Haltestelle aus einem Geofox-Vorschlag auswählen.';card.querySelector('[data-line-options]').replaceChildren();card.querySelector('[data-route-configs]').replaceChildren();card.querySelector('[data-lines-message]').textContent='Nach der Haltestellenauswahl hier die verfügbaren Linien laden.';card.querySelector('[data-load-lines]').disabled=true;lineControllers.get(card)?.abort();lineSequences.set(card,(lineSequences.get(card)||0)+1);card.querySelector('[data-routes]').replaceChildren();card.querySelector('[data-line-picker]').dataset.selectedLines='[]'}}
 function bindStation(card){{const name=card.querySelector('[data-station-field="name"]');const city=card.querySelector('[data-station-field="city"]');[name,city].forEach(input=>input.addEventListener('input',()=>{{invalidateStation(card);scheduleStationSearch(card)}}));}}
 function scheduleStationSearch(card){{clearTimeout(debounceTimers.get(card));const query=card.querySelector('[data-station-field="name"]').value.trim();if(query.length<2) return;debounceTimers.set(card,setTimeout(()=>searchStation(card),350))}}
 async function searchStation(card){{const query=card.querySelector('[data-station-field="name"]').value.trim();const city=card.querySelector('[data-station-field="city"]').value.trim();const select=card.querySelector('[data-station-results]');const message=card.querySelector('[data-search-message]');const sequence=++requestSequence;controllers.get(card)?.abort();const controller=new AbortController();controllers.set(card,controller);select.disabled=true;message.innerHTML='<span class="spinner" aria-hidden="true"></span> Geofox wird abgefragt …';try{{const response=await fetch('/api/stations?q='+encodeURIComponent(query)+'&city='+encodeURIComponent(city),{{signal:controller.signal}});const data=await response.json();if(sequence!==requestSequence)return;if(!response.ok)throw new Error(data.error||'Geofox-Suche fehlgeschlagen');select.replaceChildren(new Option('Treffer auswählen …',''));data.stations.forEach(station=>{{const option=new Option(station.combinedName,JSON.stringify(station));select.appendChild(option)}});message.textContent=data.stations.length?'Bitte passenden Treffer auswählen.':'Keine passende Haltestelle gefunden.'}}catch(error){{if(error.name!=='AbortError')message.textContent=error.message}}finally{{if(sequence===requestSequence)select.disabled=false}}}}
 function applyStation(select){{if(!select.value)return;const station=JSON.parse(select.value);const card=select.closest('[data-station]');card.querySelector('[data-station-field="name"]').value=station.name;card.querySelector('[data-station-field="city"]').value=station.city;card.querySelector('[data-station-field="id"]').value=station.id;card.querySelector('[data-station-field="serviceTypes"]').value=JSON.stringify(station.serviceTypes||[]);card.dataset.valid='true';card.querySelector('[data-search-message]').innerHTML='<span class="ok">✓ Geofox-Haltestelle ausgewählt</span>';card.querySelector('[data-load-lines]').disabled=false;card.querySelector('[data-routes]').replaceChildren();loadLines(card.querySelector('[data-load-lines]'))}}
-function addStation(){{const first=document.querySelector('[data-station]');const clone=first.cloneNode(true);clone.querySelectorAll('input').forEach(input=>input.value=input.dataset.stationField==='city'?'Hamburg':(input.dataset.stationField==='serviceTypes'?'[]':''));clone.querySelector('[data-routes]').replaceChildren();clone.querySelector('[data-line-options]').replaceChildren();clone.querySelector('[data-line-picker]').dataset.selectedLines='[]';clone.querySelector('[data-station-results]').replaceChildren(new Option('Treffer auswählen …',''));invalidateStation(clone);document.getElementById('stations').appendChild(clone);bindStation(clone)}}
-function renderLineOptions(card, lines){{const picker=card.querySelector('[data-line-picker]');const box=card.querySelector('[data-line-options]');let selected=[];try{{selected=JSON.parse(picker.dataset.selectedLines||'[]').map(item=>item.id)}}catch(error){{selected=[]}}box.replaceChildren();lines.forEach(line=>{{const label=document.createElement('label');label.className='line-option';const input=document.createElement('input');input.type='checkbox';input.dataset.lineOption='true';input.value=line.id;input.dataset.line=line.name;input.dataset.product=line.product;input.checked=selected.includes(line.id);label.append(input,document.createTextNode(line.name+' · '+line.productLabel+(line.carrier?' · '+line.carrier:'')));box.append(label)}})}}
+function addStation(){{const first=document.querySelector('[data-station]');const clone=first.cloneNode(true);clone.querySelectorAll('input').forEach(input=>input.value=input.dataset.stationField==='city'?'Hamburg':(input.dataset.stationField==='serviceTypes'?'[]':''));clone.querySelector('[data-routes]').replaceChildren();clone.querySelector('[data-line-options]').replaceChildren();clone.querySelector('[data-route-configs]').replaceChildren();clone.querySelector('[data-line-picker]').dataset.selectedLines='[]';clone.querySelector('[data-station-results]').replaceChildren(new Option('Treffer auswählen …',''));invalidateStation(clone);document.getElementById('stations').appendChild(clone);bindStation(clone)}}
+function renderRouteConfig(input, options){{const card=input.closest('[data-station]');const container=card.querySelector('[data-route-configs]');[...container.children].filter(item=>item.dataset.routeConfig===input.value).forEach(item=>item.remove());const config=document.createElement('div');config.className='route-config';config.dataset.routeConfig=input.value;const title=document.createElement('strong');title.textContent=input.dataset.line+' · Filter';const help=document.createElement('span');help.className='subtle';help.textContent='Richtung zeigt auch Kurzläufer; Zielstation ist strenger.';const mode=document.createElement('select');mode.dataset.routeMode='true';mode.setAttribute('aria-label','Filtermodus für '+input.dataset.line);mode.append(new Option('Richtung','direction'),new Option('Zu Zielstation …','destination'));const filter=document.createElement('select');filter.dataset.routeFilter='true';filter.setAttribute('aria-label','Richtung oder Zielstation für '+input.dataset.line);const target=document.createElement('input');target.type='search';target.dataset.routeTarget='true';target.placeholder='Zielstation suchen …';target.setAttribute('autocomplete','off');const targetList=document.createElement('datalist');targetList.id='route-targets-'+Math.random().toString(36).slice(2);target.setAttribute('list',targetList.id);const fill=()=>{{filter.replaceChildren();targetList.replaceChildren();if(mode.value==='direction'){{target.hidden=true;filter.hidden=false;options.forEach(option=>filter.append(new Option(option.label,JSON.stringify(option.stationIds))))}}else{{target.hidden=false;filter.hidden=true;const seen=new Set();options.forEach(option=>option.stations.forEach(station=>{{if(!seen.has(station.id)){{seen.add(station.id);const suggestion=new Option(station.name,station.name);suggestion.dataset.stationId=station.id;targetList.append(suggestion)}}}}));const selectedIds=input.dataset.filterIds?JSON.parse(input.dataset.filterIds):[];const selected=[...targetList.options].find(option=>option.dataset.stationId===selectedIds[0]);target.value=selected?.value||'';target.dataset.stationId=selected?.dataset.stationId||''}}}};mode.value=input.dataset.filterMode||'direction';mode.addEventListener('change',fill);target.addEventListener('input',()=>{{const selected=[...targetList.options].find(option=>option.value===target.value);target.dataset.stationId=selected?.dataset.stationId||'';loadTargetStations(input,target,targetList)}});config.append(title,help,mode,target,targetList,filter);container.append(config);fill();const selectedIds=input.dataset.filterIds?JSON.parse(input.dataset.filterIds):[];if(mode.value==='direction'){{const wanted=JSON.stringify(selectedIds);[...filter.options].find(option=>option.value===wanted)?.setAttribute('selected','selected')}}}}
+async function loadTargetStations(input,target,targetList){{clearTimeout(target.dataset.targetTimer);const query=target.value.trim();if(query.length<2)return;target.dataset.targetTimer=setTimeout(async()=>{{const card=input.closest('[data-station]');const stationId=card.querySelector('[data-station-field="id"]').value.trim();const sequence=(Number(target.dataset.targetSequence||'0')+1);target.dataset.targetSequence=sequence;try{{const response=await fetch('/api/line-stations?station_id='+encodeURIComponent(stationId)+'&line_id='+encodeURIComponent(input.value)+'&q='+encodeURIComponent(query));const data=await response.json();if(Number(target.dataset.targetSequence)!==sequence)return;if(!response.ok)throw new Error(data.error||'Zielstationen konnten nicht geladen werden');targetList.replaceChildren(...data.stations.map(station=>{{const option=new Option(station.name,station.name);option.dataset.stationId=station.id;return option}}));const selected=[...targetList.options].find(option=>option.value===target.value);target.dataset.stationId=selected?.dataset.stationId||''}}catch(error){{target.dataset.stationId=''}}}},250)}}
+async function loadRouteOptions(input){{const card=input.closest('[data-station]');const stationId=card.querySelector('[data-station-field="id"]').value.trim();const sequence=(Number(input.dataset.routeSequence||'0')+1);input.dataset.routeSequence=sequence;input.disabled=true;try{{const response=await fetch('/api/line-routes?station_id='+encodeURIComponent(stationId)+'&line_id='+encodeURIComponent(input.value));const data=await response.json();if(Number(input.dataset.routeSequence)!==sequence)return;if(!response.ok)throw new Error(data.error||'Richtungen konnten nicht geladen werden');input.dataset.routeOptions=JSON.stringify(data.routes);renderRouteConfig(input,data.routes);if(!data.routes.length)throw new Error('Für diese Linie konnte keine eindeutige Strecke ermittelt werden')}}catch(error){{if(Number(input.dataset.routeSequence)===sequence){{input.checked=false;card.querySelector('[data-lines-message]').textContent=error.message}}}}finally{{if(Number(input.dataset.routeSequence)===sequence)input.disabled=false}}}}
+function renderLineOptions(card, lines){{const picker=card.querySelector('[data-line-picker]');const box=card.querySelector('[data-line-options]');let selected=[];try{{selected=JSON.parse(picker.dataset.selectedLines||'[]')}}catch(error){{selected=[]}}box.replaceChildren();card.querySelector('[data-route-configs]').replaceChildren();lines.forEach(line=>{{const chosen=selected.find(item=>item.id===line.id)||{{}};const label=document.createElement('label');label.className='line-option';const input=document.createElement('input');input.type='checkbox';input.dataset.lineOption='true';input.value=line.id;input.dataset.line=line.name;input.dataset.product=line.product;input.dataset.filterMode=chosen.filterMode||'';input.dataset.filterIds=JSON.stringify(chosen.filterStationIds||[]);input.checked=Boolean(chosen.id);input.addEventListener('change',()=>input.checked?loadRouteOptions(input):card.querySelector('[data-route-configs]').querySelector('[data-route-config="'+CSS.escape(input.value)+'"]')?.remove());label.append(input,document.createTextNode(line.name+' · '+line.productLabel+(line.carrier?' · '+line.carrier:'')));box.append(label);if(input.checked)loadRouteOptions(input)}}}}
 async function loadLines(button){{const card=button.closest('[data-station]');const stationId=card.querySelector('[data-station-field="id"]').value.trim();const message=card.querySelector('[data-lines-message]');if(!stationId){{message.textContent='Bitte zuerst eine Geofox-Haltestelle auswählen.';return}}const sequence=(lineSequences.get(card)||0)+1;lineSequences.set(card,sequence);lineControllers.get(card)?.abort();const controller=new AbortController();lineControllers.set(card,controller);button.disabled=true;message.innerHTML='<span class="spinner" aria-hidden="true"></span> Linien werden geladen …';try{{const response=await fetch('/api/lines?station_id='+encodeURIComponent(stationId),{{signal:controller.signal}});const data=await response.json();if(lineSequences.get(card)!==sequence)return;if(!response.ok)throw new Error(data.error||'Linien konnten nicht geladen werden');renderLineOptions(card,data.lines);message.textContent=data.lines.length?'Linien aller verfügbaren Verkehrsmittel auswählen.':'Für diese Haltestelle wurden keine Linien gefunden.'}}catch(error){{if(error.name!=='AbortError')message.textContent=error.message}}finally{{if(lineSequences.get(card)===sequence)button.disabled=false}}}}
-function selectedRoutes(card){{const manual=[...card.querySelectorAll('[data-route="line"]')].map(line=>{{const row=line.closest('.route-row');return {{line:line.value.trim(),destination:row.querySelector('[data-route="destination"]').value.trim(),line_id:row.querySelector('[data-route-line-id]').value.trim()||undefined,product:row.querySelector('[data-route-product]').value.trim()||undefined}}}}).filter(route=>route.line&&!route.line_id);const selected=[...card.querySelectorAll('[data-line-option]')].filter(input=>input.checked).map(input=>({{line:input.dataset.line,destination:'',line_id:input.value,product:input.dataset.product}}));return [...selected,...manual]}}
+function selectedRoutes(card){{const manual=[...card.querySelectorAll('[data-route="line"]')].map(line=>{{const row=line.closest('.route-row');let ids=[];try{{ids=JSON.parse(row.querySelector('[data-route-filter-ids]')?.value||'[]')}}catch(error){{ids=[]}}return {{line:line.value.trim(),destination:row.querySelector('[data-route="destination"]').value.trim(),line_id:row.querySelector('[data-route-line-id]').value.trim()||undefined,product:row.querySelector('[data-route-product]').value.trim()||undefined,filter_mode:row.querySelector('[data-route-filter-mode]')?.value.trim()||undefined,filter_station_ids:Array.isArray(ids)?ids:[]}}}}).filter(route=>route.line);const selected=[...card.querySelectorAll('[data-line-option]')].filter(input=>input.checked).map(input=>{{const config=card.querySelector('[data-route-config="'+CSS.escape(input.value)+'"]');const mode=config?.querySelector('[data-route-mode]')?.value;const filter=config?.querySelector('[data-route-filter]');const target=config?.querySelector('[data-route-target]');let ids=[];let destination='';if(mode==='direction'&&filter?.value){{ids=JSON.parse(filter.value);destination=filter.selectedOptions[0]?.textContent||''}}else if(mode==='destination'&&target?.dataset.stationId){{ids=[target.dataset.stationId];destination=target.value.trim()}}return {{line:input.dataset.line,destination,line_id:input.value,product:input.dataset.product,filter_mode:mode||undefined,filter_station_ids:ids}}}});return selected.length?[...selected,...manual.filter(route=>!route.line_id)]:manual}}
 function prepareConfig(){{const invalid=[...document.querySelectorAll('[data-station]')].find(card=>card.dataset.valid!=='true');if(invalid){{invalid.querySelector('[data-search-message]').innerHTML='<span class="error">Bitte zuerst einen gültigen Geofox-Vorschlag auswählen.</span>';invalid.scrollIntoView({{behavior:'smooth',block:'center'}});return false}}const config=JSON.parse(document.getElementById('config_json').value);document.querySelectorAll('[data-path]').forEach(control=>{{const [section,key]=control.dataset.path.split('.');config[section][key]=control.dataset.type==='bool'?control.value==='true':(control.type==='number'?Number(control.value):control.value)}});config.stations=[...document.querySelectorAll('[data-station]')].map(card=>({{name:card.querySelector('[data-station-field="name"]').value,city:card.querySelector('[data-station-field="city"]').value,id:card.querySelector('[data-station-field="id"]').value,label:card.querySelector('[data-station-field="label"]').value,serviceTypes:JSON.parse(card.querySelector('[data-station-field="serviceTypes"]').value||'[]'),routes:selectedRoutes(card)}}));document.getElementById('config_json').value=JSON.stringify(config);document.getElementById('save-settings').disabled=true;document.getElementById('save-settings').textContent='Geofox prüft …';return true}}
 document.querySelectorAll('[data-station]').forEach(bindStation);document.querySelectorAll('[data-station-results]').forEach(select=>select.addEventListener('change',()=>applyStation(select)));
 </script>'''
@@ -644,6 +760,45 @@ def make_handler(application: WebApplication) -> type[BaseHTTPRequestHandler]:
                 except (ConfigError, OSError, ValueError) as exc:
                     self._send_json(
                         {"lines": [], "error": str(exc)}, HTTPStatus.BAD_REQUEST
+                    )
+                return
+            if path == "/api/line-routes":
+                query = parse_qs(urlsplit(self.path).query)
+                try:
+                    routes = application.line_route_suggestions(
+                        query.get("station_id", [""])[0],
+                        query.get("line_id", [""])[0],
+                    )
+                    self._send_json({"routes": routes})
+                except GeofoxError as exc:
+                    self._send_json(
+                        {"routes": [], "error": str(exc)},
+                        _geofox_http_status(exc),
+                        retry_after=exc.retry_after_seconds,
+                    )
+                except (ConfigError, OSError, ValueError) as exc:
+                    self._send_json(
+                        {"routes": [], "error": str(exc)}, HTTPStatus.BAD_REQUEST
+                    )
+                return
+            if path == "/api/line-stations":
+                query = parse_qs(urlsplit(self.path).query)
+                try:
+                    stations = application.line_station_suggestions(
+                        query.get("station_id", [""])[0],
+                        query.get("line_id", [""])[0],
+                        query.get("q", [""])[0],
+                    )
+                    self._send_json({"stations": stations})
+                except GeofoxError as exc:
+                    self._send_json(
+                        {"stations": [], "error": str(exc)},
+                        _geofox_http_status(exc),
+                        retry_after=exc.retry_after_seconds,
+                    )
+                except (ConfigError, OSError, ValueError) as exc:
+                    self._send_json(
+                        {"stations": [], "error": str(exc)}, HTTPStatus.BAD_REQUEST
                     )
                 return
             self.send_error(HTTPStatus.NOT_FOUND)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -197,6 +197,15 @@ class ConfigTest(unittest.TestCase):
         self.assertEqual(route.filter_mode, "destination")
         self.assertEqual(route.filter_station_ids, ("Master:2",))
 
+        empty_filter = json.loads(json.dumps(raw))
+        empty_filter["stations"][0]["routes"][0]["filter_mode"] = ""
+        empty_filter["stations"][0]["routes"][0]["filter_station_ids"] = []
+        with tempfile.TemporaryDirectory() as directory:
+            route = load_config(
+                self.write_config(empty_filter, directory)
+            ).stations[0].routes[0]
+        self.assertIsNone(route.filter_mode)
+
         raw["stations"][0]["routes"][0]["filter_mode"] = "unknown"
         with tempfile.TemporaryDirectory() as directory:
             with self.assertRaisesRegex(ConfigError, "filter_mode"):
@@ -206,6 +215,24 @@ class ConfigTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             with self.assertRaisesRegex(ConfigError, "filter_mode"):
                 load_config(self.write_config(raw, directory))
+
+        for field_value, message in (
+            ("not-a-list", "filter_station_ids muss eine Liste sein"),
+            (["Master:2"] * 201, "enthält zu viele Haltestellen"),
+        ):
+            invalid = json.loads(json.dumps(raw))
+            invalid["stations"][0]["routes"][0]["filter_mode"] = "destination"
+            invalid["stations"][0]["routes"][0]["filter_station_ids"] = field_value
+            with tempfile.TemporaryDirectory() as directory:
+                with self.assertRaisesRegex(ConfigError, message):
+                    load_config(self.write_config(invalid, directory))
+
+        invalid = json.loads(json.dumps(raw))
+        invalid["stations"][0]["routes"][0]["filter_mode"] = "destination"
+        invalid["stations"][0]["routes"][0]["filter_station_ids"] = []
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(ConfigError, "muss für einen Filter"):
+                load_config(self.write_config(invalid, directory))
 
     def test_optional_values_use_defaults(self) -> None:
         raw = json.loads(Path("config.example.json").read_text(encoding="utf-8"))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -181,6 +181,32 @@ class ConfigTest(unittest.TestCase):
             with self.assertRaisesRegex(ConfigError, "darf nicht leer"):
                 load_config(self.write_config(raw, directory))
 
+    def test_line_filter_route_round_trips_and_rejects_invalid_modes(self) -> None:
+        raw = json.loads(Path("config.example.json").read_text(encoding="utf-8"))
+        raw["stations"][0]["routes"] = [
+            {
+                "line": "U2",
+                "line_id": "line:U2",
+                "filter_mode": "destination",
+                "filter_station_ids": ["Master:2"],
+                "destination": "Niendorf Markt",
+            }
+        ]
+        with tempfile.TemporaryDirectory() as directory:
+            route = load_config(self.write_config(raw, directory)).stations[0].routes[0]
+        self.assertEqual(route.filter_mode, "destination")
+        self.assertEqual(route.filter_station_ids, ("Master:2",))
+
+        raw["stations"][0]["routes"][0]["filter_mode"] = "unknown"
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(ConfigError, "filter_mode"):
+                load_config(self.write_config(raw, directory))
+
+        raw["stations"][0]["routes"][0]["filter_mode"] = None
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(ConfigError, "filter_mode"):
+                load_config(self.write_config(raw, directory))
+
     def test_optional_values_use_defaults(self) -> None:
         raw = json.loads(Path("config.example.json").read_text(encoding="utf-8"))
         for field in (

--- a/tests/test_geofox.py
+++ b/tests/test_geofox.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 from hvv_display.geofox import (
     HAMBURG_TZ,
     MAX_LINE_OPTIONS,
+    MAX_ROUTE_STATION_SUGGESTIONS,
     GeofoxClient,
     GeofoxError,
     line_options_for_station,
@@ -19,7 +20,7 @@ from hvv_display.geofox import (
     route_matches,
     vehicle_type_label,
 )
-from hvv_display.models import Route, Station
+from hvv_display.models import LineRouteOption, Route, Station
 
 
 class FakeResponse:
@@ -55,6 +56,11 @@ class GeofoxClientTest(unittest.TestCase):
         self.assertTrue(route_matches("384", "S Elbgaustraße", routes))
         self.assertFalse(route_matches("184", "S Elbgaustraße", routes))
         self.assertTrue(route_matches("U2", "Niendorf Nord", routes))
+        self.assertFalse(
+            route_matches(
+                "U2", "Niendorf Nord", (Route("U2", "", "line:U2"),), "line:5"
+            )
+        )
         self.assertEqual(normalize("Recknitzstraße"), "recknitzstrasse")
 
     def test_line_options_filter_by_station_and_expose_vehicle_metadata(self) -> None:
@@ -172,6 +178,14 @@ class GeofoxClientTest(unittest.TestCase):
                             {"id": "Master:4", "name": "Mümmelmannsberg"},
                         ]
                     },
+                    {
+                        "stationSequence": [
+                            {"id": "Master:1", "name": "Jungfernstieg"},
+                            {"id": "Master:2", "name": "Niendorf Markt"},
+                            {"id": "Master:3", "name": "Niendorf Nord"},
+                        ]
+                    },
+                    {"stationSequence": [{"id": "Master:1", "name": "Endstation"}]},
                 ],
             }
         ]
@@ -194,6 +208,57 @@ class GeofoxClientTest(unittest.TestCase):
         self.assertEqual(
             line_route_options_for_station(None, "line:U2", "Master:1"), ()
         )
+        self.assertEqual(
+            line_route_options_for_station(
+                [{"id": "line:bad", "sublines": {}}], "line:bad", "Master:1"
+            ),
+            (),
+        )
+        self.assertEqual(
+            line_route_options_for_station(
+                [{"id": "line:bad", "sublines": [None, {"stationSequence": {}}]}],
+                "line:bad",
+                "Master:1",
+            ),
+            (),
+        )
+
+        many = [
+            {
+                "stationSequence": [
+                    {"id": "Master:1"},
+                    {"id": f"Master:{index + 10}"},
+                ]
+            }
+            for index in range(MAX_LINE_OPTIONS + 1)
+        ]
+        self.assertEqual(
+            len(
+                line_route_options_for_station(
+                    [{"id": "line:many", "sublines": many}],
+                    "line:many",
+                    "Master:1",
+                )
+            ),
+            MAX_LINE_OPTIONS,
+        )
+        suggestions = line_route_stations(
+            (
+                LineRouteOption(
+                    "line:U2",
+                    "Richtung Ende",
+                    tuple(
+                        f"Master:{index}"
+                        for index in range(MAX_ROUTE_STATION_SUGGESTIONS)
+                    ),
+                    tuple(
+                        (f"Master:{index}", f"Station {index}")
+                        for index in range(MAX_ROUTE_STATION_SUGGESTIONS)
+                    ),
+                ),
+            )
+        )
+        self.assertEqual(len(suggestions), MAX_ROUTE_STATION_SUGGESTIONS)
 
     def test_list_lines_requests_all_sublines(self) -> None:
         response = FakeResponse(
@@ -251,6 +316,12 @@ class GeofoxClientTest(unittest.TestCase):
             ),
         )
         self.assertEqual(line_options.line_options("Master:1"), ())
+        self.assertEqual(
+            line_options.line_route_options("Master:1", "line:5"), ()
+        )
+        self.assertEqual(
+            line_options.line_route_stations("Master:1", "line:5"), ()
+        )
 
     def test_find_stations_returns_service_types_for_follow_up_flow(self) -> None:
         response = FakeResponse(
@@ -471,6 +542,14 @@ class GeofoxClientTest(unittest.TestCase):
                     "UBAHN",
                     "destination",
                     ("Master:2",),
+                ),
+                Route(
+                    "U2",
+                    "Richtung Niendorf Nord",
+                    "line:U2",
+                    "UBAHN",
+                    "direction",
+                    ("Master:2", "Master:3"),
                 ),
             ),
             "Master:1",

--- a/tests/test_geofox.py
+++ b/tests/test_geofox.py
@@ -13,6 +13,8 @@ from hvv_display.geofox import (
     GeofoxClient,
     GeofoxError,
     line_options_for_station,
+    line_route_options_for_station,
+    line_route_stations,
     normalize,
     route_matches,
     vehicle_type_label,
@@ -147,6 +149,50 @@ class GeofoxClientTest(unittest.TestCase):
         ]
         self.assertEqual(
             len(line_options_for_station(limited, "Master:1")), MAX_LINE_OPTIONS
+        )
+
+    def test_line_route_options_build_direction_branches_and_station_suggestions(
+        self,
+    ) -> None:
+        lines = [
+            {
+                "id": "line:U2",
+                "name": "U2",
+                "sublines": [
+                    {
+                        "stationSequence": [
+                            {"id": "Master:1", "name": "Jungfernstieg"},
+                            {"id": "Master:2", "name": "Niendorf Markt"},
+                            {"id": "Master:3", "name": "Niendorf Nord"},
+                        ]
+                    },
+                    {
+                        "stationSequence": [
+                            {"id": "Master:1", "name": "Jungfernstieg"},
+                            {"id": "Master:4", "name": "Mümmelmannsberg"},
+                        ]
+                    },
+                ],
+            }
+        ]
+        options = line_route_options_for_station(lines, "line:U2", "Master:1")
+        self.assertEqual(
+            [option.label for option in options],
+            ["Richtung Niendorf Nord", "Richtung Mümmelmannsberg"],
+        )
+        self.assertEqual(
+            options[0].station_ids,
+            ("Master:2", "Master:3"),
+        )
+        self.assertEqual(
+            line_route_stations(options, "Nord"),
+            ({"id": "Master:3", "name": "Niendorf Nord"},),
+        )
+        self.assertEqual(
+            line_route_options_for_station(lines, "missing", "Master:1"), ()
+        )
+        self.assertEqual(
+            line_route_options_for_station(None, "line:U2", "Master:1"), ()
         )
 
     def test_list_lines_requests_all_sublines(self) -> None:
@@ -385,6 +431,67 @@ class GeofoxClientTest(unittest.TestCase):
             [
                 {"serviceID": "line:U2", "serviceName": "U2"},
                 {"serviceID": "line:5", "serviceName": "5"},
+            ],
+        )
+
+    def test_departures_serialize_direction_and_destination_filters(self) -> None:
+        response = FakeResponse(
+            b'{"returnCode":"OK","departures":[{"line":{"id":"line:U2",'
+            b'"name":"U2","direction":"Niendorf Markt"},"timeOffset":4}]}'
+        )
+        requests = []
+
+        def urlopen(request, **_kwargs):
+            requests.append(json.loads(request.data.decode("utf-8")))
+            return response
+
+        client = GeofoxClient(
+            "https://example.test",
+            "user",
+            "secret",
+            min_request_interval=0,
+            urlopen=urlopen,
+        )
+        station = Station(
+            "Jungfernstieg",
+            "Hamburg",
+            (
+                Route(
+                    "U2",
+                    "Richtung Niendorf Nord",
+                    "line:U2",
+                    "UBAHN",
+                    "direction",
+                    ("Master:2", "Master:3"),
+                ),
+                Route(
+                    "U2",
+                    "Niendorf Markt",
+                    "line:U2",
+                    "UBAHN",
+                    "destination",
+                    ("Master:2",),
+                ),
+            ),
+            "Master:1",
+        )
+        result = client.departure_list(
+            (station,), now=datetime(2026, 7, 27, 12, 0, tzinfo=HAMBURG_TZ)
+        )
+        self.assertEqual([departure.line for departure in result], ["U2"])
+        self.assertEqual(
+            requests[0]["filter"],
+            [
+                {
+                    "serviceID": "line:U2",
+                    "serviceName": "U2",
+                    "stationIDs": ["Master:2", "Master:3"],
+                },
+                {
+                    "serviceID": "line:U2",
+                    "serviceName": "U2",
+                    "stationIDs": ["Master:2"],
+                },
             ],
         )
 

--- a/tests/test_station_management.py
+++ b/tests/test_station_management.py
@@ -40,7 +40,10 @@ class StationManagementTest(unittest.TestCase):
         self.assertIn("Richtung oder Zielstation?", page)
         self.assertIn("Verfügbare Linien laden", page)
         self.assertIn("data-line-options", page)
-        self.assertIn("Mehrere Verkehrsmittel werden gemeinsam angeboten", page)
+        self.assertIn("data-route-configs", page)
+        self.assertIn("/api/line-routes?station_id=", page)
+        self.assertIn("Zu Zielstation", page)
+        self.assertIn("Richtung oder Zielstation festlegen", page)
 
     def test_station_search_validates_lengths_before_geofox_request(self) -> None:
         with self.assertRaisesRegex(ValueError, "zu lang"):
@@ -85,6 +88,36 @@ class StationManagementTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "ungültig"):
             self.app.line_suggestions("bad\nstation")
 
+    def test_line_route_suggestions_and_target_stations_use_cached_catalog(
+        self,
+    ) -> None:
+        lines = [
+            {
+                "id": "line:U2",
+                "name": "U2",
+                "type": "TRAIN",
+                "sublines": [
+                    {
+                        "vehicleType": "UBAHN",
+                        "stationSequence": [
+                            {"id": "Master:1", "name": "Jungfernstieg"},
+                            {"id": "Master:2", "name": "Niendorf Markt"},
+                            {"id": "Master:3", "name": "Niendorf Nord"},
+                        ],
+                    }
+                ],
+            }
+        ]
+        with patch.object(self.app, "_client") as client:
+            client.return_value.list_lines.return_value = lines
+            routes = self.app.line_route_suggestions("Master:1", "line:U2")
+            stations = self.app.line_station_suggestions(
+                "Master:1", "line:U2", "Nord"
+            )
+        self.assertEqual(routes[0]["label"], "Richtung Niendorf Nord")
+        self.assertEqual(stations, [{"id": "Master:3", "name": "Niendorf Nord"}])
+        client.return_value.list_lines.assert_called_once_with()
+
     def test_station_config_is_revalidated_and_enriched_before_save(self) -> None:
         raw = json.loads(self.config.read_text(encoding="utf-8"))
         raw["stations"] = [
@@ -125,7 +158,14 @@ class StationManagementTest(unittest.TestCase):
                 "city": "Hamburg",
                 "id": "Master:1",
                 "label": "J",
-                "routes": [{"line_id": "line:U2", "line": "untrusted"}],
+                "routes": [
+                    {
+                        "line_id": "line:U2",
+                        "line": "untrusted",
+                        "filter_mode": "destination",
+                        "filter_station_ids": ["Master:2"],
+                    }
+                ],
             }
         ]
         matches = [{"name": "Jungfernstieg", "city": "Hamburg", "id": "Master:1"}]
@@ -136,7 +176,10 @@ class StationManagementTest(unittest.TestCase):
                 "sublines": [
                     {
                         "vehicleType": "UBAHN",
-                        "stationSequence": [{"id": "Master:1"}],
+                        "stationSequence": [
+                            {"id": "Master:1", "name": "Jungfernstieg"},
+                            {"id": "Master:2", "name": "Niendorf Markt"},
+                        ],
                     }
                 ],
             }
@@ -152,7 +195,9 @@ class StationManagementTest(unittest.TestCase):
             "line_id": "line:U2",
             "line": "U2",
             "product": "UBAHN",
-            "destination": "",
+            "filter_mode": "destination",
+            "filter_station_ids": ["Master:2"],
+            "destination": "Niendorf Markt",
         })
 
         raw["stations"][0]["routes"][0]["line_id"] = "line:missing"


### PR DESCRIPTION
## Änderung\n- Geofox-Sublinien liefern dynamische Richtungsoptionen pro Linie und Haltestelle.\n- Richtung nutzt nachgelagerte stationIDs und behält Kurzläufer auf dem Linienast bei.\n- Zielstation nutzt eine serverseitig validierte Geofox-Autocomplete und schließt Kurzläufer aus.\n- Konfiguration, API-Endpunkte und Webformular validieren stabile Linien-/Stations-IDs und behalten Legacy-Routen sicher bei.\n\n## Prüfung\n- Relevante Unittests, Compileall und Ruff lokal grün\n- Paket-Build und pip-audit lokal grün\n- Einstellungen-Seite lokal gerendert und Autocomplete-Struktur geprüft\n- Linux-spezifische Bash-/Unix-Socket-Tests laufen in GitHub Actions; WSL ist lokal nicht verfügbar\n\nCloses #42