### PR TITLE
feat: konfigurierbare Zeitdarstellung

### DIFF
--- a/README.md
+++ b/README.md
@@ -684,6 +684,8 @@ ohne eingebettete Zugangsdaten, Query-Parameter oder Fragment sein.
 | `display.rotate` | `0` | Drehung; erlaubt sind 0, 1, 2 oder 3 |
 | `display.bus_speed_hz` | `16000000` | SPI-Takt; größer als 0 |
 | `display.bgr` | `false` | bei vertauschtem Rot und Blau auf `true` setzen |
+| `display.time_mode` | `countdown` | `countdown` für Minuten bis Abfahrt oder `departure_time` für die Uhrzeit |
+| `display.minute_unit` | `min` | Countdown-Einheit `min`, `m` oder `none`; bei `departure_time` nicht relevant |
 
 Für ein um 180 Grad gedrehtes Display üblicherweise `display.rotate` auf `2`
 setzen.

--- a/config.example.json
+++ b/config.example.json
@@ -15,7 +15,9 @@
     "gpio_reset": 25,
     "rotate": 0,
     "bus_speed_hz": 16000000,
-    "bgr": false
+    "bgr": false,
+    "time_mode": "countdown",
+    "minute_unit": "min"
   },
   "night_shutdown": {
     "enabled": false,

--- a/hvv_display/config.py
+++ b/hvv_display/config.py
@@ -9,6 +9,7 @@ from typing import Any
 from urllib.parse import urlsplit
 
 from .models import Route, Station
+from .time_display import MINUTE_UNITS, TIME_MODES
 
 MAX_ROUTE_FILTER_STATIONS = 200
 
@@ -37,6 +38,8 @@ class DisplayConfig:
     rotate: int
     bus_speed_hz: int
     bgr: bool
+    time_mode: str = "countdown"
+    minute_unit: str = "min"
 
 
 @dataclass(frozen=True)
@@ -141,11 +144,19 @@ def load_config(path: str | Path) -> AppConfig:
         rotate=int(display_raw.get("rotate", 0)),
         bus_speed_hz=int(display_raw.get("bus_speed_hz", 16_000_000)),
         bgr=_boolean(display_raw.get("bgr", False), "display.bgr"),
+        time_mode=str(display_raw.get("time_mode", "countdown")).strip(),
+        minute_unit=str(display_raw.get("minute_unit", "min")).strip(),
     )
     if display.rotate not in (0, 1, 2, 3):
         raise ConfigError("display.rotate muss 0, 1, 2 oder 3 sein")
     if display.bus_speed_hz <= 0:
         raise ConfigError("display.bus_speed_hz muss größer als 0 sein")
+    if display.time_mode not in TIME_MODES:
+        raise ConfigError(
+            "display.time_mode muss countdown oder departure_time sein"
+        )
+    if display.minute_unit not in MINUTE_UNITS:
+        raise ConfigError("display.minute_unit muss min, m oder none sein")
 
     night_shutdown = NightShutdownConfig(
         enabled=_boolean(

--- a/hvv_display/main.py
+++ b/hvv_display/main.py
@@ -118,6 +118,8 @@ def update_board(
     display: Ili9341Display | None,
     time_is_synchronized: bool | None = True,
     night_shutdown: bool = False,
+    time_mode: str = "countdown",
+    minute_unit: str = "min",
 ) -> tuple[object, ...]:
     """Render and transfer a frame only when its visible content changed."""
     if night_shutdown:
@@ -132,6 +134,8 @@ def update_board(
             wifi_is_connected=wifi_is_connected,
             max_rows=max_rows,
             time_is_synchronized=time_is_synchronized,
+            time_mode=time_mode,
+            minute_unit=minute_unit,
         )
     if current_state == previous_state:
         LOG.debug("Displayinhalt unverändert; Aktualisierung übersprungen")
@@ -149,6 +153,8 @@ def update_board(
             wifi_is_connected=wifi_is_connected,
             max_rows=max_rows,
             time_is_synchronized=time_is_synchronized,
+            time_mode=time_mode,
+            minute_unit=minute_unit,
         )
     if output:
         output_path = Path(output)
@@ -353,6 +359,8 @@ def run() -> int:
                     display=display,
                     time_is_synchronized=clock_ready,
                     night_shutdown=night_active,
+                    time_mode=config.display.time_mode,
+                    minute_unit=config.display.minute_unit,
                 )
             except (OSError, RuntimeError) as exc:
                 LOG.warning(

--- a/hvv_display/render.py
+++ b/hvv_display/render.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import math
 import os
 import re
 from dataclasses import dataclass
@@ -11,6 +10,7 @@ from pathlib import Path
 from PIL import Image, ImageDraw, ImageFont
 
 from .models import Departure
+from .time_display import format_departure_time
 
 WIDTH = 320
 HEIGHT = 240
@@ -250,6 +250,8 @@ def board_state_key(
     wifi_is_connected: bool | None,
     max_rows: int,
     time_is_synchronized: bool | None = True,
+    time_mode: str = "countdown",
+    minute_unit: str = "min",
 ) -> tuple[object, ...]:
     """Describe only visible state so unchanged frames need not be redrawn."""
     visible_departures = tuple(
@@ -259,15 +261,13 @@ def board_state_key(
             departure.station_label,
             departure.product,
             departure.cancelled,
-            (
-                "AUS"
-                if departure.cancelled
-                else max(
-                    0,
-                    math.ceil((departure.departure_time - now).total_seconds() / 60),
-                )
+            format_departure_time(
+                departure.departure_time,
+                now,
+                time_mode=time_mode,
+                minute_unit=minute_unit,
+                cancelled=departure.cancelled,
             ),
-            departure.departure_time.strftime("%H:%M"),
         )
         for departure in departures[:max_rows]
     )
@@ -294,6 +294,8 @@ def render_board(
     wifi_is_connected: bool | None = None,
     max_rows: int = 5,
     time_is_synchronized: bool | None = True,
+    time_mode: str = "countdown",
+    minute_unit: str = "min",
 ) -> Image.Image:
     image = Image.new("RGB", (WIDTH, HEIGHT), BLACK)
     draw = ImageDraw.Draw(image)
@@ -354,10 +356,12 @@ def render_board(
                 right_font = _font(18, bold=True)
                 right_color = RED
             else:
-                minutes = max(
-                    0, math.ceil((departure.departure_time - now).total_seconds() / 60)
+                right_text = format_departure_time(
+                    departure.departure_time,
+                    now,
+                    time_mode=time_mode,
+                    minute_unit=minute_unit,
                 )
-                right_text = "sofort" if minutes == 0 else f"{minutes} min"
                 right_font = _font(17, bold=True)
                 right_color = WHITE
             right_width = draw.textbbox((0, 0), right_text, font=right_font)[2]
@@ -367,15 +371,16 @@ def render_board(
                 font=right_font,
                 fill=right_color,
             )
-            absolute = departure.departure_time.strftime("%H:%M")
-            absolute_font = _font(10)
-            absolute_width = draw.textbbox((0, 0), absolute, font=absolute_font)[2]
-            draw.text(
-                (WIDTH - absolute_width - 8, y + 25),
-                absolute,
-                font=absolute_font,
-                fill=MUTED,
-            )
+            if time_mode != "departure_time":
+                absolute = departure.departure_time.strftime("%H:%M")
+                absolute_font = _font(10)
+                absolute_width = draw.textbbox((0, 0), absolute, font=absolute_font)[2]
+                draw.text(
+                    (WIDTH - absolute_width - 8, y + 25),
+                    absolute,
+                    font=absolute_font,
+                    fill=MUTED,
+                )
 
     status_label = _status_text(
         wifi_is_connected=wifi_is_connected,

--- a/hvv_display/time_display.py
+++ b/hvv_display/time_display.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import math
+from datetime import datetime
+
+TIME_MODES = ("countdown", "departure_time")
+MINUTE_UNITS = ("min", "m", "none")
+
+
+def minutes_until(departure_time: datetime, now: datetime) -> int:
+    """Return a non-negative, display-friendly countdown in whole minutes."""
+    return max(0, math.ceil((departure_time - now).total_seconds() / 60))
+
+
+def format_departure_time(
+    departure_time: datetime,
+    now: datetime,
+    *,
+    time_mode: str = "countdown",
+    minute_unit: str = "min",
+    cancelled: bool = False,
+) -> str:
+    """Format one effective departure time for every presentation surface."""
+    if cancelled:
+        return "AUS"
+    if time_mode == "departure_time":
+        return departure_time.strftime("%H:%M")
+    minutes = minutes_until(departure_time, now)
+    if minute_unit == "none":
+        return str(minutes)
+    return f"{minutes} {minute_unit}"

--- a/hvv_display/web.py
+++ b/hvv_display/web.py
@@ -34,6 +34,7 @@ from .geofox import (
 )
 from .render import get_line_style, line_style_css
 from .stations import resolve_stations
+from .time_display import format_departure_time, minutes_until
 
 LOG = logging.getLogger(__name__)
 DEFAULT_HOST = "127.0.0.1"
@@ -133,10 +134,16 @@ def save_config(path: Path, raw_config: dict[str, Any]) -> None:
 
 
 def _minutes_until(departure: Any, now: datetime) -> int:
-    return max(0, round((departure.departure_time - now).total_seconds() / 60))
+    return minutes_until(departure.departure_time, now)
 
 
-def _departure_payload(departures: list[Any], now: datetime) -> list[dict[str, Any]]:
+def _departure_payload(
+    departures: list[Any],
+    now: datetime,
+    *,
+    time_mode: str = "countdown",
+    minute_unit: str = "min",
+) -> list[dict[str, Any]]:
     return [
         {
             "line": departure.line,
@@ -144,7 +151,15 @@ def _departure_payload(departures: list[Any], now: datetime) -> list[dict[str, A
             "destination": departure.destination,
             "station": departure.station_label,
             "time": departure.departure_time.strftime("%H:%M"),
+            "display_time": format_departure_time(
+                departure.departure_time,
+                now,
+                time_mode=time_mode,
+                minute_unit=minute_unit,
+                cancelled=departure.cancelled,
+            ),
             "minutes": _minutes_until(departure, now),
+            "time_mode": time_mode,
             "delay_seconds": departure.delay_seconds,
             "cancelled": departure.cancelled,
         }
@@ -286,7 +301,15 @@ class WebApplication:
             max_list=30,
             max_time_offset=config.api.max_time_offset_minutes,
         )
-        return _departure_payload(departures[: config.api.max_departures], now), None
+        return (
+            _departure_payload(
+                departures[: config.api.max_departures],
+                now,
+                time_mode=config.display.time_mode,
+                minute_unit=config.display.minute_unit,
+            ),
+            None,
+        )
 
     def station_suggestions(self, query: str, city: str) -> list[dict[str, Any]]:
         query = query.strip()
@@ -506,7 +529,7 @@ class WebApplication:
             departures, error = [], str(exc)
         rows = (
             "".join(
-                f'<div class="row"><div><div class="line line-badge line-badge-{get_line_style(item.get("line", ""), item.get("product")).token}">{html.escape(str(item.get("line", "")))}</div><div class="station">{html.escape(str(item.get("station", "")))}</div></div><div class="destination">{html.escape(str(item.get("destination", "")))}{(" <span class=delay>(+" + str(item["delay_seconds"] // 60) + " min)</span>") if item["delay_seconds"] else ""}</div><div class="time {"cancelled" if item["cancelled"] else ""}">{html.escape(str(item["time"]))}<br><small>in {item["minutes"]} min</small></div></div>'
+                f'<div class="row"><div><div class="line line-badge line-badge-{get_line_style(item.get("line", ""), item.get("product")).token}">{html.escape(str(item.get("line", "")))}</div><div class="station">{html.escape(str(item.get("station", "")))}</div></div><div class="destination">{html.escape(str(item.get("destination", "")))}{(" <span class=delay>(+" + str(item["delay_seconds"] // 60) + " min)</span>") if item["delay_seconds"] else ""}</div><div class="time {"cancelled" if item["cancelled"] else ""}">{html.escape(str(item.get("display_time", item["time"]))) }{"" if item.get("time_mode") == "departure_time" else "<br><small>in " + str(item["minutes"]) + " min</small>"}</div></div>'
                 for item in departures
             )
             or '<div class="empty">Keine passende Abfahrt verfügbar.</div>'
@@ -535,6 +558,8 @@ class WebApplication:
             "display.rotate": 0,
             "display.bus_speed_hz": 16000000,
             "display.bgr": False,
+            "display.time_mode": "countdown",
+            "display.minute_unit": "min",
             "night_shutdown.enabled": False,
             "night_shutdown.start": "21:00",
             "night_shutdown.end": "06:30",
@@ -554,6 +579,8 @@ class WebApplication:
             "display.rotate": "Drehung: 0 bis 3 Vierteldrehungen.",
             "display.bus_speed_hz": "SPI-Takt in Hertz.",
             "display.bgr": "Bei vertauschten Rot-/Blaukanälen aktivieren.",
+            "display.time_mode": "Minuten bis Abfahrt oder konkrete Abfahrtszeit; gilt für Display und Web.",
+            "display.minute_unit": "Einheit für den Countdown; bei Abfahrtszeit nicht relevant.",
             "night_shutdown.enabled": "Pausiert nachts Abfragen und Display.",
             "night_shutdown.start": "Beginn in Hamburger Ortszeit (HH:MM).",
             "night_shutdown.end": "Ende in Hamburger Ortszeit (HH:MM).",
@@ -565,6 +592,10 @@ class WebApplication:
             default = defaults[path]
             if isinstance(default, bool):
                 control = f'<select id="{path}" data-path="{path}" data-type="bool" data-default="{str(default).lower()}"><option value="false" {"selected" if not value else ""}>Nein</option><option value="true" {"selected" if value else ""}>Ja</option></select>'
+            elif path == "display.time_mode":
+                control = f'<select id="{path}" data-path="{path}" data-default="countdown"><option value="countdown" {"selected" if value == "countdown" else ""}>Minuten bis Abfahrt</option><option value="departure_time" {"selected" if value == "departure_time" else ""}>Abfahrtszeit</option></select>'
+            elif path == "display.minute_unit":
+                control = f'<select id="{path}" data-path="{path}" data-default="min"><option value="min" {"selected" if value == "min" else ""}>min</option><option value="m" {"selected" if value == "m" else ""}>m</option><option value="none" {"selected" if value == "none" else ""}>keine Einheit</option></select>'
             else:
                 control = f'<input id="{path}" data-path="{path}" type="{input_type}" value="{html.escape(str(value), quote=True)}" data-default="{html.escape(str(default), quote=True)}">'
             return f'<div class="setting"><label for="{path}">{path}</label><div class="control-row">{control}<button type="button" class="reset" onclick="resetField(this)">Auf Standard zurücksetzen</button></div><div class="subtle">{descriptions[path]}</div></div>'
@@ -607,13 +638,14 @@ class WebApplication:
 <form method="post" action="/settings" accept-charset="UTF-8" onsubmit="return prepareConfig()"><section class="card"><h2>Weboberfläche</h2><p class="subtle">Benutzername: <code>hvv-anzeiger</code>. Ein leeres Passwortfeld lässt den bisherigen Wert unverändert.</p><label for="web_password">Neues Webpasswort</label><input id="web_password" name="web_password" type="password" autocomplete="new-password" placeholder="unverändert lassen"></section>
 <section class="card"><h2>Geofox-Zugang</h2><label for="user">Anwendungs-ID</label><input id="user" name="user" value="{html.escape(credentials.get("GEOFOX_USER", ""), quote=True)}" autocomplete="username"><label for="password">Passwort</label><input id="password" name="password" type="password" autocomplete="new-password" placeholder="unverändert lassen"></section>
 <section class="card"><h2>Geofox-API</h2><div class="grid">{scalar("api.base_url")}{scalar("api.version", "number")}{scalar("api.refresh_seconds", "number")}{scalar("api.request_timeout_seconds", "number")}{scalar("api.max_departures", "number")}{scalar("api.max_time_offset_minutes", "number")}{scalar("api.max_stale_age_minutes", "number")}</div></section>
-<section class="card"><h2>Display</h2><div class="grid">{scalar("display.spi_port", "number")}{scalar("display.spi_device", "number")}{scalar("display.gpio_dc", "number")}{scalar("display.gpio_reset", "number")}{scalar("display.rotate", "number")}{scalar("display.bus_speed_hz", "number")}{scalar("display.bgr")}</div></section>
+<section class="card"><h2>Display</h2><div class="grid">{scalar("display.spi_port", "number")}{scalar("display.spi_device", "number")}{scalar("display.gpio_dc", "number")}{scalar("display.gpio_reset", "number")}{scalar("display.rotate", "number")}{scalar("display.bus_speed_hz", "number")}{scalar("display.bgr")}{scalar("display.time_mode")}{scalar("display.minute_unit")}</div></section>
 <section class="card"><h2>Nachtabschaltung</h2><div class="grid">{scalar("night_shutdown.enabled")}{scalar("night_shutdown.start", "time")}{scalar("night_shutdown.end", "time")}</div></section>
 <section class="card"><div class="station-heading"><div><h2>Haltestellen und Linien</h2><p class="subtle">Haltestelle eintippen, Geofox-Vorschlag auswählen; Name, Stadt und ID werden automatisch übernommen.</p></div><button type="button" onclick="addStation()">Haltestelle hinzufügen</button></div><div id="stations">{stations}</div></section>
 <textarea id="config_json" name="config_json" hidden>{raw}</textarea><input type="hidden" name="csrf_token" value="{html.escape(self.csrf_token, quote=True)}"><p><button id="save-settings" type="submit">Speichern und prüfen</button></p></form>
 <script>
 let requestSequence=0; let debounceTimers=new WeakMap(); let controllers=new WeakMap(); let lineControllers=new WeakMap(); let lineSequences=new WeakMap();
-function resetField(button){{const control=button.parentElement.querySelector('[data-path]');control.value=control.dataset.default}}
+function resetField(button){{const control=button.parentElement.querySelector('[data-path]');control.value=control.dataset.default;syncTimeDisplayControls()}}
+function syncTimeDisplayControls(){{const mode=document.getElementById('display.time_mode');const unit=document.getElementById('display.minute_unit');if(!mode||!unit)return;unit.disabled=mode.value==='departure_time';unit.closest('.setting').querySelector('.subtle').textContent=unit.disabled?'Bei Abfahrtszeit nicht relevant.':'Einheit für den Countdown; bei Abfahrtszeit nicht relevant.'}}
 function addRoute(button){{const row=document.createElement('div');row.className='route-row';row.innerHTML='<input data-route="line" placeholder="Linie" aria-label="Linie"><input data-route="destination" placeholder="Ziel" aria-label="Ziel"><input type="hidden" data-route-line-id><input type="hidden" data-route-product><input type="hidden" data-route-filter-mode><input type="hidden" data-route-filter-ids value="[]"><button type="button" class="reset" onclick="this.parentElement.remove()">Route entfernen</button>';button.closest('[data-station]').querySelector('[data-routes]').appendChild(row)}}
 function invalidateStation(card){{card.dataset.valid='false';card.querySelector('[data-station-field="id"]').value='';card.querySelector('[data-station-field="serviceTypes"]').value='[]';card.querySelector('[data-search-message]').textContent='Bitte Haltestelle aus einem Geofox-Vorschlag auswählen.';card.querySelector('[data-line-options]').replaceChildren();card.querySelector('[data-route-configs]').replaceChildren();card.querySelector('[data-lines-message]').textContent='Nach der Haltestellenauswahl hier die verfügbaren Linien laden.';card.querySelector('[data-load-lines]').disabled=true;lineControllers.get(card)?.abort();lineSequences.set(card,(lineSequences.get(card)||0)+1);card.querySelector('[data-routes]').replaceChildren();card.querySelector('[data-line-picker]').dataset.selectedLines='[]'}}
 function bindStation(card){{const name=card.querySelector('[data-station-field="name"]');const city=card.querySelector('[data-station-field="city"]');[name,city].forEach(input=>input.addEventListener('input',()=>{{invalidateStation(card);scheduleStationSearch(card)}}));}}
@@ -624,11 +656,44 @@ function addStation(){{const first=document.querySelector('[data-station]');cons
 function renderRouteConfig(input, options){{const card=input.closest('[data-station]');const container=card.querySelector('[data-route-configs]');[...container.children].filter(item=>item.dataset.routeConfig===input.value).forEach(item=>item.remove());const config=document.createElement('div');config.className='route-config';config.dataset.routeConfig=input.value;const title=document.createElement('strong');title.textContent=input.dataset.line+' · Filter';const help=document.createElement('span');help.className='subtle';help.textContent='Richtung zeigt auch Kurzläufer; Zielstation ist strenger.';const mode=document.createElement('select');mode.dataset.routeMode='true';mode.setAttribute('aria-label','Filtermodus für '+input.dataset.line);mode.append(new Option('Richtung','direction'),new Option('Zu Zielstation …','destination'));const filter=document.createElement('select');filter.dataset.routeFilter='true';filter.setAttribute('aria-label','Richtung oder Zielstation für '+input.dataset.line);const target=document.createElement('input');target.type='search';target.dataset.routeTarget='true';target.placeholder='Zielstation suchen …';target.setAttribute('autocomplete','off');const targetList=document.createElement('datalist');targetList.id='route-targets-'+Math.random().toString(36).slice(2);target.setAttribute('list',targetList.id);const fill=()=>{{filter.replaceChildren();targetList.replaceChildren();if(mode.value==='direction'){{target.hidden=true;filter.hidden=false;options.forEach(option=>filter.append(new Option(option.label,JSON.stringify(option.stationIds))))}}else{{target.hidden=false;filter.hidden=true;const seen=new Set();options.forEach(option=>option.stations.forEach(station=>{{if(!seen.has(station.id)){{seen.add(station.id);const suggestion=new Option(station.name,station.name);suggestion.dataset.stationId=station.id;targetList.append(suggestion)}}}}));const selectedIds=input.dataset.filterIds?JSON.parse(input.dataset.filterIds):[];const selected=[...targetList.options].find(option=>option.dataset.stationId===selectedIds[0]);target.value=selected?.value||'';target.dataset.stationId=selected?.dataset.stationId||''}}}};mode.value=input.dataset.filterMode||'direction';mode.addEventListener('change',fill);target.addEventListener('input',()=>{{const selected=[...targetList.options].find(option=>option.value===target.value);target.dataset.stationId=selected?.dataset.stationId||'';loadTargetStations(input,target,targetList)}});config.append(title,help,mode,target,targetList,filter);container.append(config);fill();const selectedIds=input.dataset.filterIds?JSON.parse(input.dataset.filterIds):[];if(mode.value==='direction'){{const wanted=JSON.stringify(selectedIds);[...filter.options].find(option=>option.value===wanted)?.setAttribute('selected','selected')}}}}
 async function loadTargetStations(input,target,targetList){{clearTimeout(target.dataset.targetTimer);const query=target.value.trim();if(query.length<2)return;target.dataset.targetTimer=setTimeout(async()=>{{const card=input.closest('[data-station]');const stationId=card.querySelector('[data-station-field="id"]').value.trim();const sequence=(Number(target.dataset.targetSequence||'0')+1);target.dataset.targetSequence=sequence;try{{const response=await fetch('/api/line-stations?station_id='+encodeURIComponent(stationId)+'&line_id='+encodeURIComponent(input.value)+'&q='+encodeURIComponent(query));const data=await response.json();if(Number(target.dataset.targetSequence)!==sequence)return;if(!response.ok)throw new Error(data.error||'Zielstationen konnten nicht geladen werden');targetList.replaceChildren(...data.stations.map(station=>{{const option=new Option(station.name,station.name);option.dataset.stationId=station.id;return option}}));const selected=[...targetList.options].find(option=>option.value===target.value);target.dataset.stationId=selected?.dataset.stationId||''}}catch(error){{target.dataset.stationId=''}}}},250)}}
 async function loadRouteOptions(input){{const card=input.closest('[data-station]');const stationId=card.querySelector('[data-station-field="id"]').value.trim();const sequence=(Number(input.dataset.routeSequence||'0')+1);input.dataset.routeSequence=sequence;input.disabled=true;try{{const response=await fetch('/api/line-routes?station_id='+encodeURIComponent(stationId)+'&line_id='+encodeURIComponent(input.value));const data=await response.json();if(Number(input.dataset.routeSequence)!==sequence)return;if(!response.ok)throw new Error(data.error||'Richtungen konnten nicht geladen werden');input.dataset.routeOptions=JSON.stringify(data.routes);renderRouteConfig(input,data.routes);if(!data.routes.length)throw new Error('Für diese Linie konnte keine eindeutige Strecke ermittelt werden')}}catch(error){{if(Number(input.dataset.routeSequence)===sequence){{input.checked=false;card.querySelector('[data-lines-message]').textContent=error.message}}}}finally{{if(Number(input.dataset.routeSequence)===sequence)input.disabled=false}}}}
-function renderLineOptions(card, lines){{const picker=card.querySelector('[data-line-picker]');const box=card.querySelector('[data-line-options]');let selected=[];try{{selected=JSON.parse(picker.dataset.selectedLines||'[]')}}catch(error){{selected=[]}}box.replaceChildren();card.querySelector('[data-route-configs]').replaceChildren();lines.forEach(line=>{{const chosen=selected.find(item=>item.id===line.id)||{{}};const label=document.createElement('label');label.className='line-option';const input=document.createElement('input');input.type='checkbox';input.dataset.lineOption='true';input.value=line.id;input.dataset.line=line.name;input.dataset.product=line.product;input.dataset.filterMode=chosen.filterMode||'';input.dataset.filterIds=JSON.stringify(chosen.filterStationIds||[]);input.checked=Boolean(chosen.id);input.addEventListener('change',()=>input.checked?loadRouteOptions(input):card.querySelector('[data-route-configs]').querySelector('[data-route-config="'+CSS.escape(input.value)+'"]')?.remove());label.append(input,document.createTextNode(line.name+' · '+line.productLabel+(line.carrier?' · '+line.carrier:'')));box.append(label);if(input.checked)loadRouteOptions(input)}}}}
+function renderLineOptions(card, lines){{
+    const picker=card.querySelector('[data-line-picker]');
+    const box=card.querySelector('[data-line-options]');
+    let selected=[];
+    try{{selected=JSON.parse(picker.dataset.selectedLines||'[]')}}catch(error){{selected=[]}}
+    box.replaceChildren();
+    card.querySelector('[data-route-configs]').replaceChildren();
+    lines.forEach(line=>{{
+        const chosen=selected.find(item=>item.id===line.id)||{{}};
+        const label=document.createElement('label');
+        label.className='line-option';
+        const input=document.createElement('input');
+        input.type='checkbox';
+        input.dataset.lineOption='true';
+        input.value=line.id;
+        input.dataset.line=line.name;
+        input.dataset.product=line.product;
+        input.dataset.filterMode=chosen.filterMode||'';
+        input.dataset.filterIds=JSON.stringify(chosen.filterStationIds||[]);
+        input.checked=Boolean(chosen.id);
+        input.addEventListener('change',()=>{{
+            if(input.checked){{
+                loadRouteOptions(input);
+            }}else{{
+                card.querySelector('[data-route-configs]')
+                    .querySelector('[data-route-config="'+CSS.escape(input.value)+'"]')
+                    ?.remove();
+            }}
+        }});
+        label.append(input,document.createTextNode(line.name+' · '+line.productLabel+(line.carrier?' · '+line.carrier:'')));
+        box.append(label);
+        if(input.checked)loadRouteOptions(input);
+    }});
+}}
 async function loadLines(button){{const card=button.closest('[data-station]');const stationId=card.querySelector('[data-station-field="id"]').value.trim();const message=card.querySelector('[data-lines-message]');if(!stationId){{message.textContent='Bitte zuerst eine Geofox-Haltestelle auswählen.';return}}const sequence=(lineSequences.get(card)||0)+1;lineSequences.set(card,sequence);lineControllers.get(card)?.abort();const controller=new AbortController();lineControllers.set(card,controller);button.disabled=true;message.innerHTML='<span class="spinner" aria-hidden="true"></span> Linien werden geladen …';try{{const response=await fetch('/api/lines?station_id='+encodeURIComponent(stationId),{{signal:controller.signal}});const data=await response.json();if(lineSequences.get(card)!==sequence)return;if(!response.ok)throw new Error(data.error||'Linien konnten nicht geladen werden');renderLineOptions(card,data.lines);message.textContent=data.lines.length?'Linien aller verfügbaren Verkehrsmittel auswählen.':'Für diese Haltestelle wurden keine Linien gefunden.'}}catch(error){{if(error.name!=='AbortError')message.textContent=error.message}}finally{{if(lineSequences.get(card)===sequence)button.disabled=false}}}}
 function selectedRoutes(card){{const manual=[...card.querySelectorAll('[data-route="line"]')].map(line=>{{const row=line.closest('.route-row');let ids=[];try{{ids=JSON.parse(row.querySelector('[data-route-filter-ids]')?.value||'[]')}}catch(error){{ids=[]}}return {{line:line.value.trim(),destination:row.querySelector('[data-route="destination"]').value.trim(),line_id:row.querySelector('[data-route-line-id]').value.trim()||undefined,product:row.querySelector('[data-route-product]').value.trim()||undefined,filter_mode:row.querySelector('[data-route-filter-mode]')?.value.trim()||undefined,filter_station_ids:Array.isArray(ids)?ids:[]}}}}).filter(route=>route.line);const selected=[...card.querySelectorAll('[data-line-option]')].filter(input=>input.checked).map(input=>{{const config=card.querySelector('[data-route-config="'+CSS.escape(input.value)+'"]');const mode=config?.querySelector('[data-route-mode]')?.value;const filter=config?.querySelector('[data-route-filter]');const target=config?.querySelector('[data-route-target]');let ids=[];let destination='';if(mode==='direction'&&filter?.value){{ids=JSON.parse(filter.value);destination=filter.selectedOptions[0]?.textContent||''}}else if(mode==='destination'&&target?.dataset.stationId){{ids=[target.dataset.stationId];destination=target.value.trim()}}return {{line:input.dataset.line,destination,line_id:input.value,product:input.dataset.product,filter_mode:mode||undefined,filter_station_ids:ids}}}});return selected.length?[...selected,...manual.filter(route=>!route.line_id)]:manual}}
 function prepareConfig(){{const invalid=[...document.querySelectorAll('[data-station]')].find(card=>card.dataset.valid!=='true');if(invalid){{invalid.querySelector('[data-search-message]').innerHTML='<span class="error">Bitte zuerst einen gültigen Geofox-Vorschlag auswählen.</span>';invalid.scrollIntoView({{behavior:'smooth',block:'center'}});return false}}const config=JSON.parse(document.getElementById('config_json').value);document.querySelectorAll('[data-path]').forEach(control=>{{const [section,key]=control.dataset.path.split('.');config[section][key]=control.dataset.type==='bool'?control.value==='true':(control.type==='number'?Number(control.value):control.value)}});config.stations=[...document.querySelectorAll('[data-station]')].map(card=>({{name:card.querySelector('[data-station-field="name"]').value,city:card.querySelector('[data-station-field="city"]').value,id:card.querySelector('[data-station-field="id"]').value,label:card.querySelector('[data-station-field="label"]').value,serviceTypes:JSON.parse(card.querySelector('[data-station-field="serviceTypes"]').value||'[]'),routes:selectedRoutes(card)}}));document.getElementById('config_json').value=JSON.stringify(config);document.getElementById('save-settings').disabled=true;document.getElementById('save-settings').textContent='Geofox prüft …';return true}}
-document.querySelectorAll('[data-station]').forEach(bindStation);document.querySelectorAll('[data-station-results]').forEach(select=>select.addEventListener('change',()=>applyStation(select)));
+document.querySelectorAll('[data-station]').forEach(bindStation);document.querySelectorAll('[data-station-results]').forEach(select=>select.addEventListener('change',()=>applyStation(select)));document.getElementById('display.time_mode')?.addEventListener('change',syncTimeDisplayControls);syncTimeDisplayControls();
 </script>'''
         return _page("Einstellungen", content)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,6 +27,8 @@ class ConfigTest(unittest.TestCase):
         self.assertFalse(config.night_shutdown.enabled)
         self.assertEqual(config.night_shutdown.start.strftime("%H:%M"), "21:00")
         self.assertEqual(config.night_shutdown.end.strftime("%H:%M"), "06:30")
+        self.assertEqual(config.display.time_mode, "countdown")
+        self.assertEqual(config.display.minute_unit, "min")
 
     def test_refresh_below_limit_is_rejected(self) -> None:
         raw = json.loads(Path("config.example.json").read_text(encoding="utf-8"))
@@ -253,6 +255,8 @@ class ConfigTest(unittest.TestCase):
             "rotate",
             "bus_speed_hz",
             "bgr",
+            "time_mode",
+            "minute_unit",
         ):
             raw["display"].pop(field, None)
         raw["stations"][0].pop("label")
@@ -263,6 +267,8 @@ class ConfigTest(unittest.TestCase):
         self.assertEqual(config.api.version, 63)
         self.assertEqual(config.api.max_stale_age_minutes, 5)
         self.assertEqual(config.display.bus_speed_hz, 16_000_000)
+        self.assertEqual(config.display.time_mode, "countdown")
+        self.assertEqual(config.display.minute_unit, "min")
         self.assertEqual(config.stations[0].label, "W")
         self.assertEqual(config.stations[0].city, "Hamburg")
         self.assertFalse(config.night_shutdown.enabled)
@@ -286,6 +292,18 @@ class ConfigTest(unittest.TestCase):
                 with tempfile.TemporaryDirectory() as directory:
                     with self.assertRaisesRegex(ConfigError, message):
                         load_config(self.write_config(raw, directory))
+
+    def test_time_display_enums_are_validated(self) -> None:
+        original = json.loads(Path("config.example.json").read_text(encoding="utf-8"))
+        for field, value, message in (
+            ("time_mode", "clock", "time_mode"),
+            ("minute_unit", "minutes", "minute_unit"),
+        ):
+            raw = json.loads(json.dumps(original))
+            raw["display"][field] = value
+            with tempfile.TemporaryDirectory() as directory:
+                with self.assertRaisesRegex(ConfigError, message):
+                    load_config(self.write_config(raw, directory))
 
 
 if __name__ == "__main__":

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -28,6 +28,32 @@ class RenderTest(unittest.TestCase):
         self.assertEqual(image.size, (320, 240))
         self.assertEqual(image.mode, "RGB")
 
+    def test_time_display_modes_change_the_rendered_departure_label(self) -> None:
+        now = datetime(2026, 7, 27, 12, 0, tzinfo=HAMBURG_TZ)
+        departure = Departure("21", "Ziel", now + timedelta(minutes=7))
+        countdown = render_board([departure], now=now, minute_unit="min")
+        short_unit = render_board([departure], now=now, minute_unit="m")
+        no_unit = render_board([departure], now=now, minute_unit="none")
+        clock = render_board([departure], now=now, time_mode="departure_time")
+        self.assertNotEqual(countdown.tobytes(), short_unit.tobytes())
+        self.assertNotEqual(short_unit.tobytes(), no_unit.tobytes())
+        self.assertNotEqual(no_unit.tobytes(), clock.tobytes())
+
+    def test_board_state_uses_the_configured_time_format(self) -> None:
+        now = datetime(2026, 7, 27, 12, 0, tzinfo=HAMBURG_TZ)
+        departure = Departure("21", "Ziel", now + timedelta(minutes=7))
+        state = board_state_key(
+            [departure],
+            now=now,
+            last_updated=now,
+            stale=False,
+            error_message=None,
+            wifi_is_connected=True,
+            max_rows=5,
+            time_mode="departure_time",
+        )
+        self.assertIn("12:07", state[1][0])
+
     def test_line_styles_cover_hvv_modes_and_safe_fallback(self) -> None:
         expected = {
             ("5", "BUS"): ("bus", "pointed"),

--- a/tests/test_time_display.py
+++ b/tests/test_time_display.py
@@ -1,0 +1,61 @@
+import unittest
+from datetime import datetime, timedelta
+
+from hvv_display.geofox import HAMBURG_TZ
+from hvv_display.time_display import format_departure_time, minutes_until
+
+
+class TimeDisplayTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.now = datetime(2026, 7, 27, 18, 35, tzinfo=HAMBURG_TZ)
+
+    def test_countdown_uses_effective_time_and_never_goes_negative(self) -> None:
+        self.assertEqual(
+            minutes_until(self.now + timedelta(seconds=61), self.now), 2
+        )
+        self.assertEqual(minutes_until(self.now - timedelta(seconds=1), self.now), 0)
+        self.assertEqual(
+            format_departure_time(
+                self.now + timedelta(minutes=7), self.now, minute_unit="min"
+            ),
+            "7 min",
+        )
+
+    def test_all_countdown_units_and_zero_are_supported(self) -> None:
+        departure = self.now + timedelta(seconds=1)
+        self.assertEqual(
+            format_departure_time(departure, self.now, minute_unit="min"), "1 min"
+        )
+        self.assertEqual(
+            format_departure_time(departure, self.now, minute_unit="m"), "1 m"
+        )
+        self.assertEqual(
+            format_departure_time(departure, self.now, minute_unit="none"), "1"
+        )
+        self.assertEqual(
+            format_departure_time(self.now, self.now, minute_unit="none"), "0"
+        )
+
+    def test_departure_time_and_cancelled_variants_use_same_effective_time(
+        self,
+    ) -> None:
+        departure = self.now + timedelta(minutes=7, seconds=30)
+        self.assertEqual(
+            format_departure_time(
+                departure, self.now, time_mode="departure_time", minute_unit="m"
+            ),
+            "18:42",
+        )
+        self.assertEqual(
+            format_departure_time(
+                departure,
+                self.now,
+                time_mode="departure_time",
+                cancelled=True,
+            ),
+            "AUS",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -13,6 +13,7 @@ from hvv_display.geofox import HAMBURG_TZ
 from hvv_display.models import Departure
 from hvv_display.web import (
     WebApplication,
+    _departure_payload,
     hardware_status,
     hash_web_password,
     load_credentials,
@@ -129,6 +130,25 @@ class WebApplicationTest(unittest.TestCase):
             self.assertIn(section, settings)
         self.assertIn("Bedienbare Felder", settings)
         self.assertIn("Sekunden zwischen Abfragen", settings)
+
+    def test_settings_exposes_one_global_time_display_configuration(self) -> None:
+        settings = self.app.settings().decode("utf-8")
+        self.assertIn('id="display.time_mode"', settings)
+        self.assertIn('value="departure_time"', settings)
+        self.assertIn('id="display.minute_unit"', settings)
+        self.assertIn("syncTimeDisplayControls", settings)
+
+    def test_departure_payload_uses_the_shared_time_formatter(self) -> None:
+        now = datetime(2026, 7, 27, 18, 35, tzinfo=HAMBURG_TZ)
+        departure = Departure("21", "Ziel", now + timedelta(minutes=7, seconds=30))
+        countdown = _departure_payload([departure], now, minute_unit="m")[0]
+        clock = _departure_payload(
+            [departure], now, time_mode="departure_time", minute_unit="none"
+        )[0]
+        self.assertEqual(countdown["display_time"], "8 m")
+        self.assertEqual(countdown["minutes"], 8)
+        self.assertEqual(clock["display_time"], "18:42")
+        self.assertEqual(clock["time_mode"], "departure_time")
 
     def test_dashboard_contains_departures_hardware_status_and_restart_action(
         self,


### PR DESCRIPTION
## Änderung
- konfigurierbarer Modus countdown oder departure_time
- Countdown-Einheit min, m oder ohne Einheit
- zentrale Formatierung für Display und Web mit derselben effektiven Abfahrtszeit inklusive Verspätung
- Legacy-Konfigurationen behalten die bisherigen Countdown-Minuten bei
- Einstellungsseite bietet beide Optionen; Einheit wird bei Abfahrtszeit deaktiviert

## Prüfung
- relevante Python-Tests, Ruff, Compileall, Build und pip-audit lokal erfolgreich
- Linux-spezifischer Installer-/Unix-Socket-Test ist unter Windows nicht ausführbar und wird durch GitHub Actions geprüft

Closes #45