### PR TITLE
feat: Haltestellen-Label konfigurierbar ausblenden

### DIFF
--- a/README.md
+++ b/README.md
@@ -684,6 +684,7 @@ ohne eingebettete Zugangsdaten, Query-Parameter oder Fragment sein.
 | `display.rotate` | `0` | Drehung; erlaubt sind 0, 1, 2 oder 3 |
 | `display.bus_speed_hz` | `16000000` | SPI-Takt; größer als 0 |
 | `display.bgr` | `false` | bei vertauschtem Rot und Blau auf `true` setzen |
+| `display.show_station_label` | `true` | blaues Haltestellen-Kürzel in Display und Web anzeigen; bei mehreren Haltestellen ohne Kürzel nicht mehr direkt erkennbar |
 | `display.time_mode` | `countdown` | `countdown` für Minuten bis Abfahrt oder `departure_time` für die Uhrzeit |
 | `display.minute_unit` | `min` | Countdown-Einheit `min`, `m` oder `none`; bei `departure_time` nicht relevant |
 

--- a/config.example.json
+++ b/config.example.json
@@ -16,6 +16,7 @@
     "rotate": 0,
     "bus_speed_hz": 16000000,
     "bgr": false,
+    "show_station_label": true,
     "time_mode": "countdown",
     "minute_unit": "min"
   },

--- a/hvv_display/config.py
+++ b/hvv_display/config.py
@@ -38,6 +38,7 @@ class DisplayConfig:
     rotate: int
     bus_speed_hz: int
     bgr: bool
+    show_station_label: bool = True
     time_mode: str = "countdown"
     minute_unit: str = "min"
 
@@ -144,6 +145,10 @@ def load_config(path: str | Path) -> AppConfig:
         rotate=int(display_raw.get("rotate", 0)),
         bus_speed_hz=int(display_raw.get("bus_speed_hz", 16_000_000)),
         bgr=_boolean(display_raw.get("bgr", False), "display.bgr"),
+        show_station_label=_boolean(
+            display_raw.get("show_station_label", True),
+            "display.show_station_label",
+        ),
         time_mode=str(display_raw.get("time_mode", "countdown")).strip(),
         minute_unit=str(display_raw.get("minute_unit", "min")).strip(),
     )

--- a/hvv_display/main.py
+++ b/hvv_display/main.py
@@ -120,6 +120,7 @@ def update_board(
     night_shutdown: bool = False,
     time_mode: str = "countdown",
     minute_unit: str = "min",
+    show_station_label: bool = True,
 ) -> tuple[object, ...]:
     """Render and transfer a frame only when its visible content changed."""
     if night_shutdown:
@@ -136,6 +137,7 @@ def update_board(
             time_is_synchronized=time_is_synchronized,
             time_mode=time_mode,
             minute_unit=minute_unit,
+            show_station_label=show_station_label,
         )
     if current_state == previous_state:
         LOG.debug("Displayinhalt unverändert; Aktualisierung übersprungen")
@@ -155,6 +157,7 @@ def update_board(
             time_is_synchronized=time_is_synchronized,
             time_mode=time_mode,
             minute_unit=minute_unit,
+            show_station_label=show_station_label,
         )
     if output:
         output_path = Path(output)
@@ -361,6 +364,7 @@ def run() -> int:
                     night_shutdown=night_active,
                     time_mode=config.display.time_mode,
                     minute_unit=config.display.minute_unit,
+                    show_station_label=config.display.show_station_label,
                 )
             except (OSError, RuntimeError) as exc:
                 LOG.warning(

--- a/hvv_display/render.py
+++ b/hvv_display/render.py
@@ -218,6 +218,11 @@ def _station_badge(draw: ImageDraw.ImageDraw, x: int, y: int, label: str) -> Non
     )
 
 
+def station_label_for_display(label: str, *, show_station_label: bool) -> str:
+    """Keep station identity internal while applying the global display choice."""
+    return label if show_station_label else ""
+
+
 def _status_text(
     *,
     wifi_is_connected: bool | None,
@@ -252,13 +257,17 @@ def board_state_key(
     time_is_synchronized: bool | None = True,
     time_mode: str = "countdown",
     minute_unit: str = "min",
+    show_station_label: bool = True,
 ) -> tuple[object, ...]:
     """Describe only visible state so unchanged frames need not be redrawn."""
     visible_departures = tuple(
         (
             departure.line,
             departure.destination,
-            departure.station_label,
+            station_label_for_display(
+                departure.station_label,
+                show_station_label=show_station_label,
+            ),
             departure.product,
             departure.cancelled,
             format_departure_time(
@@ -281,6 +290,7 @@ def board_state_key(
             stale=stale,
             last_updated=last_updated,
         ),
+        show_station_label,
     )
 
 
@@ -296,6 +306,7 @@ def render_board(
     time_is_synchronized: bool | None = True,
     time_mode: str = "countdown",
     minute_unit: str = "min",
+    show_station_label: bool = True,
 ) -> Image.Image:
     image = Image.new("RGB", (WIDTH, HEIGHT), BLACK)
     draw = ImageDraw.Draw(image)
@@ -334,16 +345,20 @@ def render_board(
                 fill=ROW_LINE,
             )
             _line_badge(draw, 9, y + 6, 58, 27, departure.line, departure.product)
-            _station_badge(draw, 75, y + 10, departure.station_label)
+            station_label = station_label_for_display(
+                departure.station_label,
+                show_station_label=show_station_label,
+            )
+            _station_badge(draw, 75, y + 10, station_label)
 
             destination, destination_font = _fit_text(
                 draw,
                 departure.destination,
-                143 if departure.station_label else 164,
+                143 if station_label else 164,
                 start_size=18,
                 min_size=13,
             )
-            destination_x = 99 if departure.station_label else 76
+            destination_x = 99 if station_label else 76
             draw.text(
                 (destination_x, y + 7),
                 destination,

--- a/hvv_display/web.py
+++ b/hvv_display/web.py
@@ -32,7 +32,7 @@ from .geofox import (
     line_route_options_for_station,
     line_route_stations,
 )
-from .render import get_line_style, line_style_css
+from .render import get_line_style, line_style_css, station_label_for_display
 from .stations import resolve_stations
 from .time_display import format_departure_time, minutes_until
 
@@ -143,13 +143,17 @@ def _departure_payload(
     *,
     time_mode: str = "countdown",
     minute_unit: str = "min",
+    show_station_label: bool = True,
 ) -> list[dict[str, Any]]:
     return [
         {
             "line": departure.line,
             "product": departure.product,
             "destination": departure.destination,
-            "station": departure.station_label,
+            "station": station_label_for_display(
+                departure.station_label,
+                show_station_label=show_station_label,
+            ),
             "time": departure.departure_time.strftime("%H:%M"),
             "display_time": format_departure_time(
                 departure.departure_time,
@@ -307,6 +311,7 @@ class WebApplication:
                 now,
                 time_mode=config.display.time_mode,
                 minute_unit=config.display.minute_unit,
+                show_station_label=config.display.show_station_label,
             ),
             None,
         )
@@ -558,6 +563,7 @@ class WebApplication:
             "display.rotate": 0,
             "display.bus_speed_hz": 16000000,
             "display.bgr": False,
+            "display.show_station_label": True,
             "display.time_mode": "countdown",
             "display.minute_unit": "min",
             "night_shutdown.enabled": False,
@@ -579,6 +585,7 @@ class WebApplication:
             "display.rotate": "Drehung: 0 bis 3 Vierteldrehungen.",
             "display.bus_speed_hz": "SPI-Takt in Hertz.",
             "display.bgr": "Bei vertauschten Rot-/Blaukanälen aktivieren.",
+            "display.show_station_label": "Blendet das blaue Haltestellen-Kürzel bei jeder Abfahrt aus. Bei mehreren Haltestellen ist dann nicht mehr direkt erkennbar, zu welcher Haltestelle eine Abfahrt gehört.",
             "display.time_mode": "Minuten bis Abfahrt oder konkrete Abfahrtszeit; gilt für Display und Web.",
             "display.minute_unit": "Einheit für den Countdown; bei Abfahrtszeit nicht relevant.",
             "night_shutdown.enabled": "Pausiert nachts Abfragen und Display.",
@@ -590,7 +597,9 @@ class WebApplication:
             section, key = path.split(".")
             value = raw_config.get(section, {}).get(key, defaults[path])
             default = defaults[path]
-            if isinstance(default, bool):
+            if path == "display.show_station_label":
+                control = f'<input id="{path}" data-path="{path}" data-type="bool" type="checkbox" value="true" data-default="true" {"checked" if value is True else ""}>'
+            elif isinstance(default, bool):
                 control = f'<select id="{path}" data-path="{path}" data-type="bool" data-default="{str(default).lower()}"><option value="false" {"selected" if not value else ""}>Nein</option><option value="true" {"selected" if value else ""}>Ja</option></select>'
             elif path == "display.time_mode":
                 control = f'<select id="{path}" data-path="{path}" data-default="countdown"><option value="countdown" {"selected" if value == "countdown" else ""}>Minuten bis Abfahrt</option><option value="departure_time" {"selected" if value == "departure_time" else ""}>Abfahrtszeit</option></select>'
@@ -598,7 +607,12 @@ class WebApplication:
                 control = f'<select id="{path}" data-path="{path}" data-default="min"><option value="min" {"selected" if value == "min" else ""}>min</option><option value="m" {"selected" if value == "m" else ""}>m</option><option value="none" {"selected" if value == "none" else ""}>keine Einheit</option></select>'
             else:
                 control = f'<input id="{path}" data-path="{path}" type="{input_type}" value="{html.escape(str(value), quote=True)}" data-default="{html.escape(str(default), quote=True)}">'
-            return f'<div class="setting"><label for="{path}">{path}</label><div class="control-row">{control}<button type="button" class="reset" onclick="resetField(this)">Auf Standard zurücksetzen</button></div><div class="subtle">{descriptions[path]}</div></div>'
+            label = (
+                "Haltestellen-Label anzeigen"
+                if path == "display.show_station_label"
+                else path
+            )
+            return f'<div class="setting"><label for="{path}">{label}</label><div class="control-row">{control}<button type="button" class="reset" onclick="resetField(this)">Auf Standard zurücksetzen</button></div><div class="subtle">{descriptions[path]}</div></div>'
 
         def station_card(station: dict[str, Any], index: int) -> str:
             selected_lines = [
@@ -638,13 +652,13 @@ class WebApplication:
 <form method="post" action="/settings" accept-charset="UTF-8" onsubmit="return prepareConfig()"><section class="card"><h2>Weboberfläche</h2><p class="subtle">Benutzername: <code>hvv-anzeiger</code>. Ein leeres Passwortfeld lässt den bisherigen Wert unverändert.</p><label for="web_password">Neues Webpasswort</label><input id="web_password" name="web_password" type="password" autocomplete="new-password" placeholder="unverändert lassen"></section>
 <section class="card"><h2>Geofox-Zugang</h2><label for="user">Anwendungs-ID</label><input id="user" name="user" value="{html.escape(credentials.get("GEOFOX_USER", ""), quote=True)}" autocomplete="username"><label for="password">Passwort</label><input id="password" name="password" type="password" autocomplete="new-password" placeholder="unverändert lassen"></section>
 <section class="card"><h2>Geofox-API</h2><div class="grid">{scalar("api.base_url")}{scalar("api.version", "number")}{scalar("api.refresh_seconds", "number")}{scalar("api.request_timeout_seconds", "number")}{scalar("api.max_departures", "number")}{scalar("api.max_time_offset_minutes", "number")}{scalar("api.max_stale_age_minutes", "number")}</div></section>
-<section class="card"><h2>Display</h2><div class="grid">{scalar("display.spi_port", "number")}{scalar("display.spi_device", "number")}{scalar("display.gpio_dc", "number")}{scalar("display.gpio_reset", "number")}{scalar("display.rotate", "number")}{scalar("display.bus_speed_hz", "number")}{scalar("display.bgr")}{scalar("display.time_mode")}{scalar("display.minute_unit")}</div></section>
+<section class="card"><h2>Display</h2><div class="grid">{scalar("display.spi_port", "number")}{scalar("display.spi_device", "number")}{scalar("display.gpio_dc", "number")}{scalar("display.gpio_reset", "number")}{scalar("display.rotate", "number")}{scalar("display.bus_speed_hz", "number")}{scalar("display.bgr")}{scalar("display.show_station_label")}{scalar("display.time_mode")}{scalar("display.minute_unit")}</div></section>
 <section class="card"><h2>Nachtabschaltung</h2><div class="grid">{scalar("night_shutdown.enabled")}{scalar("night_shutdown.start", "time")}{scalar("night_shutdown.end", "time")}</div></section>
 <section class="card"><div class="station-heading"><div><h2>Haltestellen und Linien</h2><p class="subtle">Haltestelle eintippen, Geofox-Vorschlag auswählen; Name, Stadt und ID werden automatisch übernommen.</p></div><button type="button" onclick="addStation()">Haltestelle hinzufügen</button></div><div id="stations">{stations}</div></section>
 <textarea id="config_json" name="config_json" hidden>{raw}</textarea><input type="hidden" name="csrf_token" value="{html.escape(self.csrf_token, quote=True)}"><p><button id="save-settings" type="submit">Speichern und prüfen</button></p></form>
 <script>
 let requestSequence=0; let debounceTimers=new WeakMap(); let controllers=new WeakMap(); let lineControllers=new WeakMap(); let lineSequences=new WeakMap();
-function resetField(button){{const control=button.parentElement.querySelector('[data-path]');control.value=control.dataset.default;syncTimeDisplayControls()}}
+function resetField(button){{const control=button.parentElement.querySelector('[data-path]');if(control.type==='checkbox'){{control.checked=control.dataset.default==='true'}}else{{control.value=control.dataset.default}}syncTimeDisplayControls()}}
 function syncTimeDisplayControls(){{const mode=document.getElementById('display.time_mode');const unit=document.getElementById('display.minute_unit');if(!mode||!unit)return;unit.disabled=mode.value==='departure_time';unit.closest('.setting').querySelector('.subtle').textContent=unit.disabled?'Bei Abfahrtszeit nicht relevant.':'Einheit für den Countdown; bei Abfahrtszeit nicht relevant.'}}
 function addRoute(button){{const row=document.createElement('div');row.className='route-row';row.innerHTML='<input data-route="line" placeholder="Linie" aria-label="Linie"><input data-route="destination" placeholder="Ziel" aria-label="Ziel"><input type="hidden" data-route-line-id><input type="hidden" data-route-product><input type="hidden" data-route-filter-mode><input type="hidden" data-route-filter-ids value="[]"><button type="button" class="reset" onclick="this.parentElement.remove()">Route entfernen</button>';button.closest('[data-station]').querySelector('[data-routes]').appendChild(row)}}
 function invalidateStation(card){{card.dataset.valid='false';card.querySelector('[data-station-field="id"]').value='';card.querySelector('[data-station-field="serviceTypes"]').value='[]';card.querySelector('[data-search-message]').textContent='Bitte Haltestelle aus einem Geofox-Vorschlag auswählen.';card.querySelector('[data-line-options]').replaceChildren();card.querySelector('[data-route-configs]').replaceChildren();card.querySelector('[data-lines-message]').textContent='Nach der Haltestellenauswahl hier die verfügbaren Linien laden.';card.querySelector('[data-load-lines]').disabled=true;lineControllers.get(card)?.abort();lineSequences.set(card,(lineSequences.get(card)||0)+1);card.querySelector('[data-routes]').replaceChildren();card.querySelector('[data-line-picker]').dataset.selectedLines='[]'}}
@@ -692,7 +706,7 @@ function renderLineOptions(card, lines){{
 }}
 async function loadLines(button){{const card=button.closest('[data-station]');const stationId=card.querySelector('[data-station-field="id"]').value.trim();const message=card.querySelector('[data-lines-message]');if(!stationId){{message.textContent='Bitte zuerst eine Geofox-Haltestelle auswählen.';return}}const sequence=(lineSequences.get(card)||0)+1;lineSequences.set(card,sequence);lineControllers.get(card)?.abort();const controller=new AbortController();lineControllers.set(card,controller);button.disabled=true;message.innerHTML='<span class="spinner" aria-hidden="true"></span> Linien werden geladen …';try{{const response=await fetch('/api/lines?station_id='+encodeURIComponent(stationId),{{signal:controller.signal}});const data=await response.json();if(lineSequences.get(card)!==sequence)return;if(!response.ok)throw new Error(data.error||'Linien konnten nicht geladen werden');renderLineOptions(card,data.lines);message.textContent=data.lines.length?'Linien aller verfügbaren Verkehrsmittel auswählen.':'Für diese Haltestelle wurden keine Linien gefunden.'}}catch(error){{if(error.name!=='AbortError')message.textContent=error.message}}finally{{if(lineSequences.get(card)===sequence)button.disabled=false}}}}
 function selectedRoutes(card){{const manual=[...card.querySelectorAll('[data-route="line"]')].map(line=>{{const row=line.closest('.route-row');let ids=[];try{{ids=JSON.parse(row.querySelector('[data-route-filter-ids]')?.value||'[]')}}catch(error){{ids=[]}}return {{line:line.value.trim(),destination:row.querySelector('[data-route="destination"]').value.trim(),line_id:row.querySelector('[data-route-line-id]').value.trim()||undefined,product:row.querySelector('[data-route-product]').value.trim()||undefined,filter_mode:row.querySelector('[data-route-filter-mode]')?.value.trim()||undefined,filter_station_ids:Array.isArray(ids)?ids:[]}}}}).filter(route=>route.line);const selected=[...card.querySelectorAll('[data-line-option]')].filter(input=>input.checked).map(input=>{{const config=card.querySelector('[data-route-config="'+CSS.escape(input.value)+'"]');const mode=config?.querySelector('[data-route-mode]')?.value;const filter=config?.querySelector('[data-route-filter]');const target=config?.querySelector('[data-route-target]');let ids=[];let destination='';if(mode==='direction'&&filter?.value){{ids=JSON.parse(filter.value);destination=filter.selectedOptions[0]?.textContent||''}}else if(mode==='destination'&&target?.dataset.stationId){{ids=[target.dataset.stationId];destination=target.value.trim()}}return {{line:input.dataset.line,destination,line_id:input.value,product:input.dataset.product,filter_mode:mode||undefined,filter_station_ids:ids}}}});return selected.length?[...selected,...manual.filter(route=>!route.line_id)]:manual}}
-function prepareConfig(){{const invalid=[...document.querySelectorAll('[data-station]')].find(card=>card.dataset.valid!=='true');if(invalid){{invalid.querySelector('[data-search-message]').innerHTML='<span class="error">Bitte zuerst einen gültigen Geofox-Vorschlag auswählen.</span>';invalid.scrollIntoView({{behavior:'smooth',block:'center'}});return false}}const config=JSON.parse(document.getElementById('config_json').value);document.querySelectorAll('[data-path]').forEach(control=>{{const [section,key]=control.dataset.path.split('.');config[section][key]=control.dataset.type==='bool'?control.value==='true':(control.type==='number'?Number(control.value):control.value)}});config.stations=[...document.querySelectorAll('[data-station]')].map(card=>({{name:card.querySelector('[data-station-field="name"]').value,city:card.querySelector('[data-station-field="city"]').value,id:card.querySelector('[data-station-field="id"]').value,label:card.querySelector('[data-station-field="label"]').value,serviceTypes:JSON.parse(card.querySelector('[data-station-field="serviceTypes"]').value||'[]'),routes:selectedRoutes(card)}}));document.getElementById('config_json').value=JSON.stringify(config);document.getElementById('save-settings').disabled=true;document.getElementById('save-settings').textContent='Geofox prüft …';return true}}
+function prepareConfig(){{const invalid=[...document.querySelectorAll('[data-station]')].find(card=>card.dataset.valid!=='true');if(invalid){{invalid.querySelector('[data-search-message]').innerHTML='<span class="error">Bitte zuerst einen gültigen Geofox-Vorschlag auswählen.</span>';invalid.scrollIntoView({{behavior:'smooth',block:'center'}});return false}}const config=JSON.parse(document.getElementById('config_json').value);document.querySelectorAll('[data-path]').forEach(control=>{{const [section,key]=control.dataset.path.split('.');config[section][key]=control.dataset.type==='bool'?(control.type==='checkbox'?control.checked:control.value==='true'):(control.type==='number'?Number(control.value):control.value)}});config.stations=[...document.querySelectorAll('[data-station]')].map(card=>({{name:card.querySelector('[data-station-field="name"]').value,city:card.querySelector('[data-station-field="city"]').value,id:card.querySelector('[data-station-field="id"]').value,label:card.querySelector('[data-station-field="label"]').value,serviceTypes:JSON.parse(card.querySelector('[data-station-field="serviceTypes"]').value||'[]'),routes:selectedRoutes(card)}}));document.getElementById('config_json').value=JSON.stringify(config);document.getElementById('save-settings').disabled=true;document.getElementById('save-settings').textContent='Geofox prüft …';return true}}
 document.querySelectorAll('[data-station]').forEach(bindStation);document.querySelectorAll('[data-station-results]').forEach(select=>select.addEventListener('change',()=>applyStation(select)));document.getElementById('display.time_mode')?.addEventListener('change',syncTimeDisplayControls);syncTimeDisplayControls();
 </script>'''
         return _page("Einstellungen", content)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -29,6 +29,7 @@ class ConfigTest(unittest.TestCase):
         self.assertEqual(config.night_shutdown.end.strftime("%H:%M"), "06:30")
         self.assertEqual(config.display.time_mode, "countdown")
         self.assertEqual(config.display.minute_unit, "min")
+        self.assertTrue(config.display.show_station_label)
 
     def test_refresh_below_limit_is_rejected(self) -> None:
         raw = json.loads(Path("config.example.json").read_text(encoding="utf-8"))
@@ -90,6 +91,12 @@ class ConfigTest(unittest.TestCase):
     def test_string_boolean_is_rejected(self) -> None:
         raw = json.loads(Path("config.example.json").read_text(encoding="utf-8"))
         raw["display"]["bgr"] = "false"
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(ConfigError, "true oder false"):
+                load_config(self.write_config(raw, directory))
+
+        raw = json.loads(Path("config.example.json").read_text(encoding="utf-8"))
+        raw["display"]["show_station_label"] = "false"
         with tempfile.TemporaryDirectory() as directory:
             with self.assertRaisesRegex(ConfigError, "true oder false"):
                 load_config(self.write_config(raw, directory))
@@ -255,6 +262,7 @@ class ConfigTest(unittest.TestCase):
             "rotate",
             "bus_speed_hz",
             "bgr",
+            "show_station_label",
             "time_mode",
             "minute_unit",
         ):
@@ -269,6 +277,7 @@ class ConfigTest(unittest.TestCase):
         self.assertEqual(config.display.bus_speed_hz, 16_000_000)
         self.assertEqual(config.display.time_mode, "countdown")
         self.assertEqual(config.display.minute_unit, "min")
+        self.assertTrue(config.display.show_station_label)
         self.assertEqual(config.stations[0].label, "W")
         self.assertEqual(config.stations[0].city, "Hamburg")
         self.assertFalse(config.night_shutdown.enabled)

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -154,6 +154,49 @@ class RenderTest(unittest.TestCase):
         )
         self.assertNotEqual(without_label.tobytes(), with_label.tobytes())
 
+    def test_station_label_can_be_hidden_without_leaving_a_badge_or_layout_gap(
+        self,
+    ) -> None:
+        now = datetime(2026, 7, 27, 12, 0, tzinfo=HAMBURG_TZ)
+        departure = Departure(
+            "21",
+            "U Niendorf Nord",
+            now + timedelta(minutes=3),
+            station_label="R",
+        )
+        hidden = render_board(
+            [departure],
+            now=now,
+            show_station_label=False,
+        )
+        no_label = render_board(
+            [Departure("21", "U Niendorf Nord", now + timedelta(minutes=3))],
+            now=now,
+        )
+        self.assertEqual(hidden.tobytes(), no_label.tobytes())
+
+    def test_hidden_station_label_is_not_part_of_visible_state(self) -> None:
+        now = datetime(2026, 7, 27, 12, 0, tzinfo=HAMBURG_TZ)
+        with_label = Departure(
+            "21", "Ziel", now + timedelta(minutes=3), station_label="W"
+        )
+        other_label = Departure(
+            "21", "Ziel", now + timedelta(minutes=3), station_label="R"
+        )
+        arguments = {
+            "now": now,
+            "last_updated": now,
+            "stale": False,
+            "error_message": None,
+            "wifi_is_connected": True,
+            "max_rows": 5,
+            "show_station_label": False,
+        }
+        self.assertEqual(
+            board_state_key([with_label], **arguments),
+            board_state_key([other_label], **arguments),
+        )
+
     def test_disconnected_wifi_has_visible_red_status_bar(self) -> None:
         now = datetime(2026, 7, 27, 12, 0, tzinfo=HAMBURG_TZ)
         connected = render_board(

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -138,6 +138,14 @@ class WebApplicationTest(unittest.TestCase):
         self.assertIn('id="display.minute_unit"', settings)
         self.assertIn("syncTimeDisplayControls", settings)
 
+    def test_settings_exposes_an_accessible_station_label_checkbox(self) -> None:
+        settings = self.app.settings().decode("utf-8")
+        self.assertIn('id="display.show_station_label"', settings)
+        self.assertIn('type="checkbox"', settings)
+        self.assertIn("Haltestellen-Label anzeigen", settings)
+        self.assertIn("Bei mehreren Haltestellen", settings)
+        self.assertIn("control.type==='checkbox'?control.checked", settings)
+
     def test_departure_payload_uses_the_shared_time_formatter(self) -> None:
         now = datetime(2026, 7, 27, 18, 35, tzinfo=HAMBURG_TZ)
         departure = Departure("21", "Ziel", now + timedelta(minutes=7, seconds=30))
@@ -149,6 +157,13 @@ class WebApplicationTest(unittest.TestCase):
         self.assertEqual(countdown["minutes"], 8)
         self.assertEqual(clock["display_time"], "18:42")
         self.assertEqual(clock["time_mode"], "departure_time")
+
+        hidden = _departure_payload(
+            [departure], now, show_station_label=False
+        )[0]
+        self.assertEqual(hidden["station"], "")
+        self.assertEqual(hidden["line"], departure.line)
+        self.assertEqual(hidden["destination"], departure.destination)
 
     def test_dashboard_contains_departures_hardware_status_and_restart_action(
         self,


### PR DESCRIPTION
## Änderung
- neue globale Option display.show_station_label, Default 	rue und Legacy-Fallback
- zugänglicher Checkbox-Toggle in der Web-Settings-Seite mit Hinweis für mehrere Haltestellen
- gemeinsame Präsentationslogik für physisches Display und Web; Sortierung, Filterung und interne Station-Information bleiben unverändert
- ausgeblendete Labels hinterlassen keine Badge-Fläche oder Layout-Lücke

## Prüfung
- 76 relevante Tests, Ruff und Compileall lokal erfolgreich
- Browserprüfung der Settings-Seite und Checkbox-Darstellung erfolgreich
- vollständiger Windows-Lauf nur mit bekannten Linux-/Unix-Einschränkungen offen
- Build und pip-audit erfolgreich

Closes #47